### PR TITLE
Add test for failing quickcheck proof.

### DIFF
--- a/dslx_prove_quickcheck_test.bzl
+++ b/dslx_prove_quickcheck_test.bzl
@@ -19,7 +19,7 @@ def _dslx_prove_quickcheck_test_impl(ctx):
         fail("Please set XLSYNTH_TOOLS environment variable")
 
     # Ensure the interpreter binary exists
-    xlsynth_tool_dir, xlsynth_driver_file = get_driver_path(ctx)
+    xlsynth_tool_dir, _xlsynth_driver_file = get_driver_path(ctx)
     prove_quickcheck_main_file = xlsynth_tool_dir + "/prove_quickcheck_main"
 
     lib = ctx.attr.lib[DslxInfo]

--- a/sample_failing_quickcheck/BUILD.bazel
+++ b/sample_failing_quickcheck/BUILD.bazel
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-load("//:rules.bzl", "dslx_library", "dslx_test")
+load("//:rules.bzl", "dslx_library", "dslx_test", "dslx_prove_quickcheck_test")
 
 dslx_library(
     name = "failing_quickcheck",
@@ -10,4 +10,10 @@ dslx_library(
 dslx_test(
     name = "failing_quickcheck_test",
     deps = [":failing_quickcheck"],
+)
+
+dslx_prove_quickcheck_test(
+    name = "failing_quickcheck_proof_test",
+    lib = ":failing_quickcheck",
+    top = "always_fail",
 )

--- a/sample_failing_quickcheck/failing_quickcheck.x
+++ b/sample_failing_quickcheck/failing_quickcheck.x
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[quickcheck]
-fn always_fail() -> bool { false }
+fn always_fail(t: (u1, u2)) -> bool { false }


### PR DESCRIPTION
(Previously there was no test that demonstrated the behavior of a proof failure failing the test suite.)