### PR TITLE
The runner is no longer a source-file label dependency of DSLX…

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,1 +1,5 @@
-exports_files(["xlsynth_runner.py"])
+py_binary(
+    name = "xlsynth_runner",
+    srcs = ["xlsynth_runner.py"],
+    main = "xlsynth_runner.py",
+)

--- a/dslx_fmt.bzl
+++ b/dslx_fmt.bzl
@@ -13,11 +13,12 @@ def _dslx_format_impl(ctx):
         formatted_files.append(formatted_file)
 
         ctx.actions.run_shell(
-            inputs=[input_file, ctx.file._runner],
+            inputs=[input_file],
+            tools=[ctx.executable._runner],
             outputs=[formatted_file],
-            command="/usr/bin/env python3 \"$1\" tool dslx_fmt \"$2\" > \"$3\"",
+            command="\"$1\" tool dslx_fmt \"$2\" > \"$3\"",
             arguments=[
-                ctx.file._runner.path,
+                ctx.executable._runner.path,
                 input_file.path,
                 formatted_file.path,
             ],
@@ -47,8 +48,9 @@ dslx_fmt_test = rule(
     attrs={
         "srcs": attr.label_list(allow_files=[".x"], allow_empty=False, doc="Source files to check formatting"),
         "_runner": attr.label(
-            default = Label("//:xlsynth_runner.py"),
-            allow_single_file = [".py"],
+            default = Label("//:xlsynth_runner"),
+            executable = True,
+            cfg = "exec",
         ),
     },
     doc="A rule that checks if the given DSLX files are properly formatted.",

--- a/dslx_prove_quickcheck_test.bzl
+++ b/dslx_prove_quickcheck_test.bzl
@@ -13,14 +13,14 @@ def _dslx_prove_quickcheck_test_impl(ctx):
 
     srcs = get_srcs_from_lib(ctx)
 
-    cmd = "/usr/bin/env python3 {} tool prove_quickcheck_main {}".format(
-        ctx.file._runner.short_path,
+    cmd = "{} tool prove_quickcheck_main {}".format(
+        ctx.executable._runner.short_path,
         lib_src.short_path,
     )
     if ctx.attr.top:
         cmd += " --test_filter=" + ctx.attr.top
 
-    runfiles = ctx.runfiles(srcs + [ctx.file._runner])
+    runfiles = ctx.runfiles(srcs + [ctx.executable._runner])
     executable_file = write_executable_shell_script(
         ctx = ctx,
         filename = ctx.label.name + ".sh",
@@ -46,8 +46,9 @@ dslx_prove_quickcheck_test = rule(
             doc = "The quickcheck function to be tested. If none is provided, all quickcheck functions in the library will be tested.",
         ),
         "_runner": attr.label(
-            default = Label("//:xlsynth_runner.py"),
-            allow_single_file = [".py"],
+            default = Label("//:xlsynth_runner"),
+            executable = True,
+            cfg = "exec",
         ),
     },
     test = True,

--- a/dslx_provider.bzl
+++ b/dslx_provider.bzl
@@ -60,12 +60,10 @@ def _dslx_library_impl(ctx):
 
     # Run typechecking via the runner so env is read at action runtime, not in Starlark.
     ctx.actions.run(
-        inputs = srcs + [ctx.file._runner],
+        inputs = srcs,
         outputs = [typecheck_output],
-        executable = "/usr/bin/env",
+        executable = ctx.executable._runner,
         arguments = [
-            "python3",
-            ctx.file._runner.path,
             "tool",
             "typecheck_main",
             srcs[-1].path,
@@ -96,8 +94,9 @@ dslx_library = rule(
             allow_files = [".x"],
         ),
         "_runner": attr.label(
-            default = Label("//:xlsynth_runner.py"),
-            allow_single_file = [".py"],
+            default = Label("//:xlsynth_runner"),
+            executable = True,
+            cfg = "exec",
         ),
     },
 )

--- a/dslx_stitch_pipeline.bzl
+++ b/dslx_stitch_pipeline.bzl
@@ -42,11 +42,12 @@ def _dslx_stitch_pipeline_impl(ctx):
         flags_str += " --{}={}".format(flag, str(value).lower())
 
     ctx.actions.run_shell(
-        inputs = srcs + [ctx.file._runner],
+        inputs = srcs,
+        tools = [ctx.executable._runner],
         outputs = [ctx.outputs.sv_file],
-        command = "/usr/bin/env python3 \"$1\" driver dslx-stitch-pipeline --dslx_input_file=\"$2\" --dslx_top=\"$3\"" + flags_str + " > \"$4\"",
+        command = "\"$1\" driver dslx-stitch-pipeline --dslx_input_file=\"$2\" --dslx_top=\"$3\"" + flags_str + " > \"$4\"",
         arguments = [
-            ctx.file._runner.path,
+            ctx.executable._runner.path,
             main_src.path,
             ctx.attr.top,
             ctx.outputs.sv_file.path,
@@ -101,8 +102,9 @@ dslx_stitch_pipeline = rule(
             default = True,
         ),
         "_runner": attr.label(
-            default = Label("//:xlsynth_runner.py"),
-            allow_single_file = [".py"],
+            default = Label("//:xlsynth_runner"),
+            executable = True,
+            cfg = "exec",
         ),
     },
     outputs = {

--- a/dslx_test.bzl
+++ b/dslx_test.bzl
@@ -33,12 +33,12 @@ def _dslx_test_impl(ctx):
     # The order of the srcs matters. dslx_interpreter_main runs tests from the first file.
     srcs = test_src + srcs_from_deps
 
-    cmd = "/usr/bin/env python3 {} tool dslx_interpreter_main {}".format(
-        ctx.file._runner.short_path,
+    cmd = "{} tool dslx_interpreter_main {}".format(
+        ctx.executable._runner.short_path,
         " ".join([src.short_path for src in srcs]),
     )
 
-    runfiles = ctx.runfiles(srcs + [ctx.file._runner])
+    runfiles = ctx.runfiles(srcs + [ctx.executable._runner])
     executable_file = write_executable_shell_script(
         ctx = ctx,
         filename = ctx.label.name + ".sh",
@@ -68,8 +68,9 @@ dslx_test = rule(
             providers = [DslxInfo],
         ),
         "_runner": attr.label(
-            default = Label("//:xlsynth_runner.py"),
-            allow_single_file = [".py"],
+            default = Label("//:xlsynth_runner"),
+            executable = True,
+            cfg = "exec",
         ),
     },
     test = True,

--- a/dslx_to_ir.bzl
+++ b/dslx_to_ir.bzl
@@ -20,11 +20,12 @@ def _dslx_to_ir_impl(ctx):
 
     # Stage 1: dslx2ir
     ctx.actions.run_shell(
-        inputs = all_transitive_srcs + [ctx.file._runner],
+        inputs = all_transitive_srcs,
+        tools = [ctx.executable._runner],
         outputs = [ctx.outputs.ir_file],
-        command = "/usr/bin/env python3 \"$1\" driver dslx2ir --dslx_input_file=\"$2\" --dslx_top=\"$3\" > \"$4\"",
+        command = "\"$1\" driver dslx2ir --dslx_input_file=\"$2\" --dslx_top=\"$3\" > \"$4\"",
         arguments = [
-            ctx.file._runner.path,
+            ctx.executable._runner.path,
             main_src.path,
             ctx.attr.top,
             ctx.outputs.ir_file.path,
@@ -38,11 +39,12 @@ def _dslx_to_ir_impl(ctx):
 
     # Stage 2: ir2opt
     ctx.actions.run_shell(
-        inputs = [ctx.outputs.ir_file, ctx.file._runner],
+        inputs = [ctx.outputs.ir_file],
+        tools = [ctx.executable._runner],
         outputs = [ctx.outputs.opt_ir_file],
-        command = "/usr/bin/env python3 \"$1\" driver ir2opt \"$2\" --top \"$3\" > \"$4\"",
+        command = "\"$1\" driver ir2opt \"$2\" --top \"$3\" > \"$4\"",
         arguments = [
-            ctx.file._runner.path,
+            ctx.executable._runner.path,
             ctx.outputs.ir_file.path,
             ir_top,
             ctx.outputs.opt_ir_file.path,
@@ -71,8 +73,9 @@ dslx_to_ir = rule(
             mandatory = True,
         ),
         "_runner": attr.label(
-            default = Label("//:xlsynth_runner.py"),
-            allow_single_file = [".py"],
+            default = Label("//:xlsynth_runner"),
+            executable = True,
+            cfg = "exec",
         ),
     },
     outputs = {

--- a/dslx_to_pipeline.bzl
+++ b/dslx_to_pipeline.bzl
@@ -60,11 +60,12 @@ def _dslx_to_pipeline_impl(ctx):
     output_opt_ir_file = ctx.outputs.opt_ir_file
 
     ctx.actions.run_shell(
-        inputs = srcs + [ctx.file._runner],
+        inputs = srcs,
+        tools = [ctx.executable._runner],
         outputs = [output_sv_file, output_unopt_ir_file, output_opt_ir_file],
-        command = "/usr/bin/env python3 \"$1\" driver dslx2pipeline --dslx_input_file=\"$2\" --dslx_top=\"$3\" --output_unopt_ir=\"$4\" --output_opt_ir=\"$5\"" + flags_str + " > \"$6\"",
+        command = "\"$1\" driver dslx2pipeline --dslx_input_file=\"$2\" --dslx_top=\"$3\" --output_unopt_ir=\"$4\" --output_opt_ir=\"$5\"" + flags_str + " > \"$6\"",
         arguments = [
-            ctx.file._runner.path,
+            ctx.executable._runner.path,
             srcs[0].path,
             top_entry,
             output_unopt_ir_file.path,
@@ -135,8 +136,9 @@ DslxToPipelineAttrs = {
         mandatory = True,
     ),
     "_runner": attr.label(
-        default = Label("//:xlsynth_runner.py"),
-        allow_single_file = [".py"],
+        default = Label("//:xlsynth_runner"),
+        executable = True,
+        cfg = "exec",
     ),
 }
 

--- a/dslx_to_sv_types.bzl
+++ b/dslx_to_sv_types.bzl
@@ -10,11 +10,12 @@ def _dslx_to_sv_types_impl(ctx):
     output_sv_file = ctx.outputs.sv_file
 
     ctx.actions.run_shell(
-        inputs = srcs + [ctx.file._runner],
+        inputs = srcs,
+        tools = [ctx.executable._runner],
         outputs = [output_sv_file],
-        command = "/usr/bin/env python3 \"$1\" driver dslx2sv-types --dslx_input_file=\"$2\" > \"$3\"",
+        command = "\"$1\" driver dslx2sv-types --dslx_input_file=\"$2\" > \"$3\"",
         arguments = [
-            ctx.file._runner.path,
+            ctx.executable._runner.path,
             srcs[0].path,
             output_sv_file.path,
         ],
@@ -35,8 +36,9 @@ dslx_to_sv_types = rule(
             providers = [DslxInfo],
         ),
         "_runner": attr.label(
-            default = Label("//:xlsynth_runner.py"),
-            allow_single_file = [".py"],
+            default = Label("//:xlsynth_runner"),
+            executable = True,
+            cfg = "exec",
         ),
     },
     outputs = {

--- a/ir_prove_equiv_test.bzl
+++ b/ir_prove_equiv_test.bzl
@@ -14,8 +14,8 @@ def _ir_prove_equiv_test_impl(ctx):
     lhs_file = list(lhs_files)[0]
     rhs_file = list(rhs_files)[0]
 
-    cmd = "/usr/bin/env python3 {} driver ir-equiv --top={} {} {}".format(
-        ctx.file._runner.short_path,
+    cmd = "{} driver ir-equiv --top={} {} {}".format(
+        ctx.executable._runner.short_path,
         ctx.attr.top,
         lhs_file.short_path,
         rhs_file.short_path,
@@ -28,7 +28,7 @@ def _ir_prove_equiv_test_impl(ctx):
     return DefaultInfo(
         files = depset(direct = [run_script]),
         runfiles = ctx.runfiles(
-            files = [lhs_file, rhs_file, ctx.file._runner],
+            files = [lhs_file, rhs_file, ctx.executable._runner],
         ),
         executable = run_script,
     )
@@ -53,8 +53,9 @@ ir_prove_equiv_test = rule(
             doc = "The top entity to check in the IR files.",
         ),
         "_runner": attr.label(
-            default = Label("//:xlsynth_runner.py"),
-            allow_single_file = [".py"],
+            default = Label("//:xlsynth_runner"),
+            executable = True,
+            cfg = "exec",
         ),
     },
     executable = True,

--- a/ir_to_delay_info.bzl
+++ b/ir_to_delay_info.bzl
@@ -8,11 +8,12 @@ def _ir_to_delay_info_impl(ctx):
     output_file = ctx.outputs.delay_info
 
     ctx.actions.run_shell(
-        inputs = [opt_ir_file, ctx.file._runner],
+        inputs = [opt_ir_file],
+        tools = [ctx.executable._runner],
         outputs = [output_file],
-        command = "/usr/bin/env python3 \"$1\" driver ir2delayinfo --delay_model=\"$2\" \"$3\" \"$4\" > \"$5\"",
+        command = "\"$1\" driver ir2delayinfo --delay_model=\"$2\" \"$3\" \"$4\" > \"$5\"",
         arguments = [
-            ctx.file._runner.path,
+            ctx.executable._runner.path,
             ctx.attr.delay_model,
             opt_ir_file.path,
             ctx.attr.top,
@@ -47,8 +48,9 @@ ir_to_delay_info = rule(
             default = False,
         ),
         "_runner": attr.label(
-            default = Label("//:xlsynth_runner.py"),
-            allow_single_file = [".py"],
+            default = Label("//:xlsynth_runner"),
+            executable = True,
+            cfg = "exec",
         ),
     },
     outputs = {

--- a/ir_to_gates.bzl
+++ b/ir_to_gates.bzl
@@ -10,11 +10,12 @@ def _ir_to_gates_impl(ctx):
     metrics_file = ctx.outputs.metrics_json
 
     ctx.actions.run_shell(
-        inputs = [ir_file_to_use, ctx.file._runner],
+        inputs = [ir_file_to_use],
+        tools = [ctx.executable._runner],
         outputs = [gates_file, metrics_file],
-        command = "/usr/bin/env python3 \"$1\" driver ir2gates --fraig=\"$2\" --output_json=\"$3\" \"$4\" > \"$5\"",
+        command = "\"$1\" driver ir2gates --fraig=\"$2\" --output_json=\"$3\" \"$4\" > \"$5\"",
         arguments = [
-            ctx.file._runner.path,
+            ctx.executable._runner.path,
             ("true" if ctx.attr.fraig else "false"),
             metrics_file.path,
             ir_file_to_use.path,
@@ -44,8 +45,9 @@ ir_to_gates = rule(
             default = True,
         ),
         "_runner": attr.label(
-            default = Label("//:xlsynth_runner.py"),
-            allow_single_file = [".py"],
+            default = Label("//:xlsynth_runner"),
+            executable = True,
+            cfg = "exec",
         ),
     },
     outputs = {


### PR DESCRIPTION
… rules. It is now a tool (py_binary) in exec configuration.

- In typical usage, bazel query 'kind("source file", deps(<your target>))' will stop listing @rules_xlsynth//:xlsynth_runner.py, because the target no longer depends on that file label.
- Note: if you query in ways that traverse into exec deps and then expand rule sources, you could still see runner sources transitively (e.g., with specialized query patterns). For normal deps() queries people use for source enumeration, this removes the spurious match.

Unintended side effects to be aware of

- Visibility/name change: external users who depended directly on @rules_xlsynth//:xlsynth_runner.py (uncommon) will need to use @rules_xlsynth//:xlsynth_runner. The file label is no longer exported as a target.
- Python toolchain: execution now uses Bazel’s Python toolchain (py_binary) instead of system /usr/bin/env python3. This generally improves reproducibility, but environments without a Python toolchain configured could notice. The runner is already 3.6+ compatible.
- Runfiles behavior: test wrappers now invoke the binary (ctx.executable._runner.short_path) instead of python3 <short_path>. This is consistent with Bazel’s runfiles setup and should behave the same as before on supported platforms.