### PR TITLE
Extend set of dslx_to_pipeline arguments

### DIFF
--- a/dslx_to_pipeline.bzl
+++ b/dslx_to_pipeline.bzl
@@ -39,6 +39,7 @@ def _dslx_to_pipeline_impl(ctx):
         "use_system_verilog",
         "reset_data_path",
         "reset_active_low",
+        "reset_asynchronous",
     ]
     for flag in bool_flags:
         value = getattr(ctx.attr, flag)
@@ -202,6 +203,10 @@ DslxToPipelineAttrs = {
     ),
     "reset_active_low": attr.bool(
         doc = "Whether reset is active low.",
+        default = False,
+    ),
+    "reset_asynchronous": attr.bool(
+        doc = "Whether reset is asynchronous.",
         default = False,
     ),
     "top": attr.string(

--- a/dslx_to_pipeline.bzl
+++ b/dslx_to_pipeline.bzl
@@ -57,6 +57,12 @@ def _dslx_to_pipeline_impl(ctx):
     if ctx.attr.reset:
         passthrough.append("--reset={}".format(ctx.attr.reset))
 
+    ir_top = ctx.attr.ir_top
+    if ir_top == "":
+        file_name = srcs[0].path.rsplit("/", 1)[1] if "/" in srcs[0].path else srcs[0].path
+        basename = file_name.split(".", 1)[0] if "." in file_name else file_name
+        ir_top = "__{}__{}".format(basename, ctx.attr.top)
+
     output_sv_file = ctx.outputs.sv_file
     output_unopt_ir_file = ctx.outputs.unopt_ir_file
     output_opt_ir_file = ctx.outputs.opt_ir_file
@@ -71,28 +77,64 @@ def _dslx_to_pipeline_impl(ctx):
         add_invariant_assertions = ctx.attr.add_invariant_assertions,
     )
 
+    common_args = [
+        "driver",
+        "--driver_path",
+        toolchain.driver_path,
+        "--runtime_library_path",
+        toolchain.runtime_library_path,
+        "--toolchain",
+        toolchain_file.path,
+    ]
+
     ctx.actions.run(
         inputs = srcs + [toolchain_file] + get_driver_artifact_inputs(
             toolchain,
-            ["ir_converter_main", "opt_main", "codegen_main"],
+            ["ir_converter_main"],
         ),
+        tools = [runner],
         executable = runner,
-        outputs = [output_sv_file, output_unopt_ir_file, output_opt_ir_file],
-        arguments = [
-            "driver",
-            "--driver_path",
-            toolchain.driver_path,
-            "--runtime_library_path",
-            toolchain.runtime_library_path,
-            "--toolchain",
-            toolchain_file.path,
+        outputs = [output_unopt_ir_file],
+        arguments = common_args + [
             "--stdout_path",
-            output_sv_file.path,
-            "dslx2pipeline",
+            output_unopt_ir_file.path,
+            "dslx2ir",
             "--dslx_input_file=" + srcs[0].path,
             "--dslx_top=" + top_entry,
-            "--output_unopt_ir=" + output_unopt_ir_file.path,
-            "--output_opt_ir=" + output_opt_ir_file.path,
+        ],
+        use_default_shell_env = False,
+    )
+
+    ctx.actions.run(
+        inputs = srcs + [output_unopt_ir_file, toolchain_file] + get_driver_artifact_inputs(
+            toolchain, ["opt_main"],
+        ),
+        tools = [runner],
+        executable = runner,
+        outputs = [output_opt_ir_file],
+        arguments = common_args + [
+            "--stdout_path",
+            output_opt_ir_file.path,
+            "ir2opt",
+            output_unopt_ir_file.path,
+            "--top=" + ir_top,
+        ],
+        use_default_shell_env = False,
+    )
+
+    ctx.actions.run(
+        inputs = srcs + [output_opt_ir_file, toolchain_file] + get_driver_artifact_inputs(
+            toolchain, ["codegen_main"],
+        ),
+        tools = [runner],
+        executable = runner,
+        outputs = [output_sv_file],
+        arguments = common_args + [
+            "--stdout_path",
+            output_sv_file.path,
+            "ir2pipeline",
+            "--top=" + ir_top,
+            output_opt_ir_file.path,
         ] + passthrough,
         use_default_shell_env = False,
     )
@@ -164,6 +206,10 @@ DslxToPipelineAttrs = {
     "xls_bundle": attr.label(
         doc = "Optional override bundle repo label, for example @legacy_xls_toolchain//:bundle.",
         providers = [XlsArtifactBundleInfo],
+    ),
+    "ir_top": attr.string(
+        doc = "The name of top entry in the intermediate representation, by default the same as: __{file_name}__{DSLX top}",
+        default = "",
     ),
 }
 

--- a/dslx_to_pipeline.bzl
+++ b/dslx_to_pipeline.bzl
@@ -36,6 +36,7 @@ def _dslx_to_pipeline_impl(ctx):
     bool_flags = [
         "flop_inputs",
         "flop_outputs",
+        "use_system_verilog",
         "reset_data_path",
     ]
     for flag in bool_flags:
@@ -129,6 +130,10 @@ DslxToPipelineAttrs = {
     ),
     "flop_outputs": attr.bool(
         doc = "Whether to flop the output ports.",
+        default = True,
+    ),
+    "use_system_verilog": attr.bool(
+        doc = "Emit SystemVerilog when true, plain Verilog when false.",
         default = True,
     ),
     "reset_data_path": attr.bool(

--- a/dslx_to_pipeline.bzl
+++ b/dslx_to_pipeline.bzl
@@ -38,6 +38,7 @@ def _dslx_to_pipeline_impl(ctx):
         "flop_outputs",
         "use_system_verilog",
         "reset_data_path",
+        "reset_active_low",
     ]
     for flag in bool_flags:
         value = getattr(ctx.attr, flag)
@@ -198,6 +199,10 @@ DslxToPipelineAttrs = {
     "reset": attr.string(
         doc = "The reset signal to use in generation.",
         default = "",
+    ),
+    "reset_active_low": attr.bool(
+        doc = "Whether reset is active low.",
+        default = False,
     ),
     "top": attr.string(
         doc = "The top entry function within the dependency module.",

--- a/sample/sample_main_sv.opt.golden.ir
+++ b/sample/sample_main_sv.opt.golden.ir
@@ -5,3 +5,4 @@ file_number 0 "sample/sample.x"
 top fn __sample__main() -> bits[32] {
   ret literal.7: bits[32] = literal(value=42, id=7, pos=[(0,5,24)])
 }
+

--- a/sample/sample_main_sv.unopt.golden.ir
+++ b/sample/sample_main_sv.unopt.golden.ir
@@ -9,3 +9,4 @@ top fn __sample__main() -> bits[32] {
   literal.4: bits[1] = literal(value=1, id=4, pos=[(0,5,47)])
   ret shrl.5: bits[32] = shrl(shll.3, literal.4, id=5, pos=[(0,5,24)])
 }
+


### PR DESCRIPTION
This PR adds following `dslx2pipeline` args:
* `use_system_verilog`,
* `reset_active_low`,
* `reset_asynchronous`.

Moreover, it modifies the flow - instead of calling `dslx2pipeline`, it is split into three stages: `dslx2ir`, `ir2opt` and `ir2pipeline`. This allows to specify the top from IR, enabling the codegen of `proc`s.