### PR TITLE
bundle: expose the standalone AOT runtime archive

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -12,7 +12,8 @@ flags.
 
 Each `xls.toolchain(...)` call exposes one runtime repo and one toolchain repo.
 `@<name>_runtime` contains the selected tool binaries, the DSLX stdlib tree,
-the matching `libxls` shared library, and the runtime-facing exports.
+the matching `libxls` shared library, the standalone AOT static runtime archive
+when that XLS line provides one, and the runtime-facing exports.
 `@<name>_toolchain` contains the `:bundle` target, the registered toolchain
 target, and a declared `:xlsynth-driver` target. Loading or registering the
 toolchain repo is metadata-only; the driver target copies, validates,
@@ -22,6 +23,8 @@ is:
 
 - `@<name>_runtime//:libxls`
 - `@<name>_runtime//:libxls_link`
+- `@<name>_runtime//:xls_aot_runtime` when the selected XLS line provides the archive
+- `@<name>_runtime//:xls_aot_runtime_file` when the selected XLS line provides the archive
 - `@<name>_runtime//:dslx_stdlib`
 - `@<name>_runtime//:xlsynth_sys_artifact_config`
 - `@<name>_runtime//:xlsynth_sys_legacy_stdlib`
@@ -46,7 +49,11 @@ The `xlsynth_sys_*` exports are the intended downstream contract for
 `rules_rust` `crate_extension.annotation(...)` wiring. The preferred modern
 shape is `build_script_data` / `build_script_env` for the build-script
 contract, plus `deps = ["@<name>_runtime//:xlsynth_sys_dep"]` for the combined
-runtime-plus-link contract. The compatibility exports
+runtime-plus-link contract. `xlsynth-aot-runtime` reuses the same artifact
+config file so its build script can find the matching standalone runtime archive
+without a parallel bundle surface. Bundle lines that predate the archive may
+omit it; that preserves non-AOT consumers while still causing an AOT build to
+fail if it selects an archive-less bundle. The compatibility exports
 `xlsynth_sys_runtime_files` and `xlsynth_sys_link_dep` remain available for
 callers that still spell those phases separately. This lets root `MODULE.bazel`
 files choose only a bundle and a build-script mode instead of coupling to

--- a/README.md
+++ b/README.md
@@ -102,9 +102,11 @@ do not use that repo directly or publish it with `use_repo(...)`.
 The runtime repo exposes:
 
 - `@<name>_runtime//:libxls` and `@<name>_runtime//:libxls_link` for native consumers
+- `@<name>_runtime//:xls_aot_runtime` and `@<name>_runtime//:xls_aot_runtime_file`
+  when the selected XLS line provides the standalone AOT static runtime archive
 - `@<name>_runtime//:dslx_stdlib` for packages that need the standard library tree
 - `@<name>_runtime//:xlsynth_sys_artifact_config` for the modern single-file
-  `xlsynth-sys` build-script contract
+  build-script contract shared by `xlsynth-sys` and `xlsynth-aot-runtime`
 - `@<name>_runtime//:xlsynth_sys_legacy_stdlib` and
   `@<name>_runtime//:xlsynth_sys_legacy_dso` for frozen `xlsynth-sys` releases that
   still use the paired `DSLX_STDLIB_PATH` / `XLS_DSO_PATH` contract
@@ -120,7 +122,12 @@ The runtime repo exposes:
 `xlsynth_sys_dep`, and, for frozen releases, `xlsynth_sys_legacy_stdlib` plus
 `xlsynth_sys_legacy_dso`, rather than spelling generic bundle internals like
 `artifact_config`, `libxls_file`, `libxls`, or `dslx_stdlib` directly in
-downstream `MODULE.bazel` files.
+downstream `MODULE.bazel` files. `xlsynth-aot-runtime` consumers should reuse
+the same artifact-config export so their build scripts receive the matching
+standalone runtime archive without a second bundle contract. Older bundles may
+omit the archive entirely; that keeps non-AOT consumers on old XLS lines valid
+while making an AOT consumer fail locally if it selects a bundle that cannot
+provide the archive it needs.
 
 Supported DSLX rules may opt out of the registered default bundle with
 `xls_bundle = "@<name>_toolchain//:bundle"`. Today that escape hatch is available on

--- a/artifact_resolution_test.py
+++ b/artifact_resolution_test.py
@@ -68,6 +68,7 @@ class ArtifactResolutionTest(unittest.TestCase):
                 "/tools/xlsynth/v0.38.0",
                 "/tools/xlsynth/v0.38.0/xls/dslx/stdlib",
                 "/tools/xlsynth/v0.38.0/libxls.dylib" if sys.platform == "darwin" else "/tools/xlsynth/v0.38.0/libxls.so",
+                "/tools/xlsynth/v0.38.0/libxls_aot_runtime.a",
             ],
         )
 
@@ -129,12 +130,29 @@ class ArtifactResolutionTest(unittest.TestCase):
             local_dslx_stdlib_path = "/tmp/xls-local-dev/stdlib",
             local_driver_path = "/tmp/xls-local-dev/xlsynth-driver",
             local_libxls_path = "/tmp/xls-local-dev/libxls.so",
+            local_xls_aot_runtime_path = "/tmp/xls-local-dev/libxls_aot_runtime.a",
         )
         self.assertEqual(plan["mode"], "local_paths")
         self.assertEqual(
             materialize_xls_bundle.derive_runtime_library_path(plan["libxls"]),
             "/tmp/xls-local-dev",
         )
+        self.assertEqual(
+            plan["xls_aot_runtime"],
+            Path("/tmp/xls-local-dev/libxls_aot_runtime.a"),
+        )
+
+    def test_local_paths_allow_bundle_without_static_aot_runtime(self):
+        plan = materialize_xls_bundle.resolve_artifact_plan(
+            artifact_source = "local_paths",
+            xls_version = "",
+            driver_version = "",
+            local_tools_path = "/tmp/xls-local-dev/tools",
+            local_dslx_stdlib_path = "/tmp/xls-local-dev/stdlib",
+            local_driver_path = "/tmp/xls-local-dev/xlsynth-driver",
+            local_libxls_path = "/tmp/xls-local-dev/libxls.so",
+        )
+        self.assertIsNone(plan["xls_aot_runtime"])
 
     def test_resolve_driver_plan_prefers_installed_driver(self):
         plan = materialize_xls_bundle.resolve_driver_plan(
@@ -286,6 +304,7 @@ printf 'fallback body\\n'
         self.assertEqual(plan["driver"], Path("/eda-tools/xlsynth-driver/0.33.0/bin/xlsynth-driver"))
         expected_name = "libxls.dylib" if sys.platform == "darwin" else "libxls.so"
         self.assertEqual(plan["libxls"].name, expected_name)
+        self.assertEqual(plan["xls_aot_runtime"].name, "libxls_aot_runtime.a")
 
     def test_build_driver_environment_sets_runtime_library_search_path(self):
         libxls_path = "/tmp/xls-bundle/libxls.dylib" if sys.platform == "darwin" else "/tmp/xls-bundle/libxls.so"
@@ -394,6 +413,7 @@ printf 'fallback body\\n'
             for binary in materialize_xls_bundle.TOOL_BINARIES:
                 (download_root / binary).write_text("", encoding = "utf-8")
             (download_root / "libxls-v0.38.0-arm64.dylib").write_text("", encoding = "utf-8")
+            (download_root / "libxls_aot_runtime-arm64.a").write_text("", encoding = "utf-8")
 
             with mock.patch.object(materialize_xls_bundle, "detect_host_platform", return_value = "arm64"):
                 with mock.patch.object(materialize_xls_bundle.subprocess, "run") as mock_run:
@@ -405,7 +425,28 @@ printf 'fallback body\\n'
                 resolved["libxls"],
                 download_root / "libxls-v0.38.0-arm64.dylib",
             )
+            self.assertEqual(
+                resolved["xls_aot_runtime"],
+                download_root / "libxls_aot_runtime-arm64.a",
+            )
             self.assertEqual(resolved["runtime_files"], [])
+            mock_run.assert_not_called()
+
+    def test_download_versioned_artifacts_reuses_valid_cache_without_aot_runtime(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            download_root = repo_root / "_downloaded_xls" / "arm64" / "0.38.0"
+            (download_root / "xls" / "dslx" / "stdlib").mkdir(parents = True)
+            (download_root / "xls" / "dslx" / "stdlib" / "std.x").write_text("// stdlib\n", encoding = "utf-8")
+            for binary in materialize_xls_bundle.TOOL_BINARIES:
+                (download_root / binary).write_text("", encoding = "utf-8")
+            (download_root / "libxls-v0.38.0-arm64.dylib").write_text("", encoding = "utf-8")
+
+            with mock.patch.object(materialize_xls_bundle, "detect_host_platform", return_value = "arm64"):
+                with mock.patch.object(materialize_xls_bundle.subprocess, "run") as mock_run:
+                    resolved = materialize_xls_bundle.download_versioned_artifacts(repo_root, "0.38.0")
+
+            self.assertIsNone(resolved["xls_aot_runtime"])
             mock_run.assert_not_called()
 
     def test_load_runtime_manifest_returns_runtime_files(self):
@@ -572,6 +613,8 @@ Tag        Type                         Name/Value
 
             libxls_path = input_root / "libxls-v0.38.0.so"
             libxls_path.write_text("xls\n", encoding = "utf-8")
+            xls_aot_runtime_path = input_root / "libxls_aot_runtime.a"
+            xls_aot_runtime_path.write_text("aot\n", encoding = "utf-8")
             runtime_companion = input_root / "libc++.so.1"
             runtime_companion.write_text("runtime\n", encoding = "utf-8")
 
@@ -586,6 +629,7 @@ Tag        Type                         Name/Value
                         "tools_root": tools_root,
                         "dslx_stdlib_root": stdlib_root,
                         "libxls": libxls_path,
+                        "xls_aot_runtime": xls_aot_runtime_path,
                         "runtime_files": [runtime_companion],
                     },
                 )
@@ -595,9 +639,15 @@ Tag        Type                         Name/Value
                 for line in (repo_root / "runtime_metadata.txt").read_text(encoding = "utf-8").splitlines()
                 if line
             )
+            artifact_config = (repo_root / "xlsynth_artifact_config.toml").read_text(
+                encoding = "utf-8"
+            )
             self.assertEqual(metadata["libxls_name"], "libxls.so")
+            self.assertEqual(metadata["xls_aot_runtime_name"], "libxls_aot_runtime.a")
             self.assertEqual(metadata["libxls_runtime_aliases"], "libxls-v0.38.0.so")
             self.assertEqual(metadata["libxls_runtime_files"], "libc++.so.1")
+            self.assertIn('aot_runtime_path = "libxls_aot_runtime.a"', artifact_config)
+            self.assertTrue((repo_root / "libxls_aot_runtime.a").is_file())
             self.assertTrue((repo_root / "libc++.so.1").is_file())
 
     def test_materialize_toolchain_surface_records_driver_capabilities(self):
@@ -612,6 +662,8 @@ Tag        Type                         Name/Value
             driver_path.write_text("", encoding = "utf-8")
             libxls_path = input_root / "libxls.so"
             libxls_path.write_text("xls\n", encoding = "utf-8")
+            xls_aot_runtime_path = input_root / "libxls_aot_runtime.a"
+            xls_aot_runtime_path.write_text("aot\n", encoding = "utf-8")
             runtime_companion = input_root / "libc++.so.1"
             runtime_companion.write_text("runtime\n", encoding = "utf-8")
 
@@ -623,6 +675,7 @@ Tag        Type                         Name/Value
                     "driver": driver_path,
                     "dslx_stdlib_root": stdlib_root,
                     "libxls": libxls_path,
+                    "xls_aot_runtime": xls_aot_runtime_path,
                     "runtime_files": [runtime_companion],
                 },
             ):

--- a/download_release.py
+++ b/download_release.py
@@ -56,6 +56,10 @@ def build_dso_release_filename(platform, version_tuple):
     return filename
 
 
+def build_static_aot_runtime_release_filename(platform):
+    return "libxls_aot_runtime-{}.a".format(platform)
+
+
 def build_runtime_tarball_release_filename(platform):
     return "libxls-runtime-{}.tar.gz".format(platform)
 
@@ -258,6 +262,15 @@ def main():
 
     for artifact, is_binary in artifacts:
         high_integrity_download(base_url, artifact, options.output_dir, options.max_attempts, is_binary, options.platform)
+
+    if options.dso:
+        try_high_integrity_download(
+            base_url,
+            build_static_aot_runtime_release_filename(options.platform),
+            options.output_dir,
+            options.max_attempts,
+            is_binary = False,
+        )
 
     # Download and extract dslx_stdlib.tar.gz
     stdlib_filename = "dslx_stdlib.tar.gz"

--- a/download_release_test.py
+++ b/download_release_test.py
@@ -72,6 +72,16 @@ class DownloadReleaseTest(unittest.TestCase):
             "libxls-runtime-ubuntu2004-manifest.json",
         )
 
+    def test_static_aot_runtime_release_filename_is_platform_scoped(self):
+        self.assertEqual(
+            download_release.build_static_aot_runtime_release_filename("arm64"),
+            "libxls_aot_runtime-arm64.a",
+        )
+        self.assertEqual(
+            download_release.build_static_aot_runtime_release_filename("ubuntu2004"),
+            "libxls_aot_runtime-ubuntu2004.a",
+        )
+
     def test_copy_url_to_path_retries_after_stream_reset(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             destination_path = f"{temp_dir}/artifact"

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -76,14 +76,29 @@ def _driver_supports_sv_struct_field_ordering(driver_version):
         return True
     return _version_at_least(driver_version, "0.36.0")
 
-def _runtime_build_file(libxls_name, runtime_files, runtime_aliases):
+def _runtime_build_file(libxls_name, xls_aot_runtime_name, runtime_files, runtime_aliases):
     tool_list = ",\n        ".join(['"{}"'.format(name) for name in _TOOL_BINARIES])
-    exported_files = ",\n    ".join(
-        ['"{}"'.format(name) for name in _TOOL_BINARIES + [libxls_name] + runtime_files + runtime_aliases],
-    )
+    exported_names = _TOOL_BINARIES + [libxls_name] + runtime_files + runtime_aliases
+    if xls_aot_runtime_name:
+        exported_names.append(xls_aot_runtime_name)
+    exported_files = ",\n    ".join(['"{}"'.format(name) for name in exported_names])
     runtime_file_srcs = ",\n        ".join(['"{}"'.format(name) for name in runtime_files])
     runtime_alias_srcs = ",\n        ".join(['"{}"'.format(name) for name in runtime_aliases])
     lib_target = libxls_name
+    aot_runtime_rule = """
+filegroup(
+    name = "xls_aot_runtime_file",
+    srcs = ["{xls_aot_runtime_name}"],
+    visibility = ["//visibility:public"],
+)
+cc_import(
+    name = "xls_aot_runtime",
+    static_library = ":xls_aot_runtime_file",
+    visibility = ["//visibility:public"],
+)
+""".format(
+        xls_aot_runtime_name = xls_aot_runtime_name,
+    ) if xls_aot_runtime_name else ""
     lib_file_rule = """
 filegroup(
     name = "libxls_file",
@@ -135,12 +150,14 @@ copy_flat_files_to_directory(
 )
 
 {lib_file_rule}
+{aot_runtime_rule}
 
 xlsynth_artifact_config(
     name = "artifact_config",
     dso_name = "{libxls_name}",
     dslx_stdlib = ":dslx_stdlib",
     shared_library = ":libxls_file",
+    static_aot_runtime = {static_aot_runtime},
     visibility = ["//visibility:public"],
 )
 
@@ -188,6 +205,7 @@ xls_runtime_surface(
     name = "runtime",
     dslx_stdlib = ":dslx_stdlib",
     libxls = ":libxls_file",
+    xls_aot_runtime = {static_aot_runtime},
     runtime_files = [":libxls_runtime_files"],
     tools_root = ":tools_root_files",
     visibility = ["//visibility:public"],
@@ -197,6 +215,8 @@ xls_runtime_surface(
         tool_list = tool_list,
         libxls_name = libxls_name,
         lib_file_rule = lib_file_rule.strip(),
+        aot_runtime_rule = aot_runtime_rule.strip(),
+        static_aot_runtime = '":xls_aot_runtime_file"' if xls_aot_runtime_name else "None",
     )
 
 def _string_attr_line(name, value):
@@ -347,6 +367,8 @@ def _materialize_bundle_args(repo_ctx, surface):
         args.extend(["--local-driver-path", repo_ctx.attr.local_driver_path])
     if repo_ctx.attr.local_libxls_path:
         args.extend(["--local-libxls-path", repo_ctx.attr.local_libxls_path])
+    if repo_ctx.attr.local_xls_aot_runtime_path:
+        args.extend(["--local-xls-aot-runtime-path", repo_ctx.attr.local_xls_aot_runtime_path])
     return args
 
 def _runtime_repo_impl(repo_ctx):
@@ -375,6 +397,7 @@ def _runtime_repo_impl(repo_ctx):
         "BUILD.bazel",
         _runtime_build_file(
             libxls_name = metadata["libxls_name"],
+            xls_aot_runtime_name = metadata["xls_aot_runtime_name"],
             runtime_files = runtime_files,
             runtime_aliases = runtime_aliases,
         ),
@@ -415,6 +438,7 @@ _runtime_repo_attrs = {
     "local_driver_path": attr.string(),
     "local_dslx_stdlib_path": attr.string(),
     "local_libxls_path": attr.string(),
+    "local_xls_aot_runtime_path": attr.string(),
     "local_tools_path": attr.string(),
     "xls_version": attr.string(),
     "xlsynth_driver_version": attr.string(),
@@ -428,6 +452,7 @@ _toolchain_repo_attrs = {
     "local_driver_path": attr.string(),
     "local_dslx_stdlib_path": attr.string(),
     "local_libxls_path": attr.string(),
+    "local_xls_aot_runtime_path": attr.string(),
     "local_tools_path": attr.string(),
     "repo_alias": attr.string(mandatory = True),
     "runtime_repo_name": attr.string(mandatory = True),
@@ -470,6 +495,7 @@ _toolchain_tag = tag_class(attrs = {
     "local_driver_path": attr.string(),
     "local_dslx_stdlib_path": attr.string(),
     "local_libxls_path": attr.string(),
+    "local_xls_aot_runtime_path": attr.string(),
     "local_tools_path": attr.string(),
     "name": attr.string(mandatory = True),
     "xls_version": attr.string(),
@@ -490,6 +516,7 @@ def _xls_extension_impl(module_ctx):
                 local_driver_path = toolchain.local_driver_path,
                 local_dslx_stdlib_path = toolchain.local_dslx_stdlib_path,
                 local_libxls_path = toolchain.local_libxls_path,
+                local_xls_aot_runtime_path = toolchain.local_xls_aot_runtime_path,
                 local_tools_path = toolchain.local_tools_path,
                 xls_version = toolchain.xls_version,
                 xlsynth_driver_version = toolchain.xlsynth_driver_version,
@@ -508,6 +535,7 @@ def _xls_extension_impl(module_ctx):
                 local_driver_path = toolchain.local_driver_path,
                 local_dslx_stdlib_path = toolchain.local_dslx_stdlib_path,
                 local_libxls_path = toolchain.local_libxls_path,
+                local_xls_aot_runtime_path = toolchain.local_xls_aot_runtime_path,
                 local_tools_path = toolchain.local_tools_path,
                 repo_alias = toolchain_name,
                 runtime_repo_name = runtime_name,

--- a/external_bundle_exports_test.py
+++ b/external_bundle_exports_test.py
@@ -81,6 +81,7 @@ class ExternalBundleExportsTest(unittest.TestCase):
         expected_dso_name = expected_libxls_name()
         self.assertEqual(config_lines["dso_path"].strip('"'), expected_dso_name)
         self.assertEqual(config_lines["dslx_stdlib_path"].strip('"'), "dslx_stdlib")
+        self.assertNotIn("aot_runtime_path", config_lines)
         self.assertTrue((config_path.parent / expected_dso_name).is_file())
         self.assertTrue((config_path.parent / "dslx_stdlib").is_dir())
 

--- a/materialize_xls_bundle.py
+++ b/materialize_xls_bundle.py
@@ -61,6 +61,10 @@ def libxls_name_for_platform(sys_platform):
         raise RuntimeError("Unsupported host platform: {}".format(sys_platform))
 
 
+def static_aot_runtime_name():
+    return "libxls_aot_runtime.a"
+
+
 def derive_installed_paths(
         xls_version,
         driver_version,
@@ -75,6 +79,7 @@ def derive_installed_paths(
         "dslx_stdlib_root": tools_root / "xls" / "dslx" / "stdlib",
         "driver": Path(installed_driver_root_prefix) / normalized_driver_version / "bin" / "xlsynth-driver",
         "libxls": tools_root / libxls_name_for_platform(sys_platform),
+        "xls_aot_runtime": tools_root / static_aot_runtime_name(),
     }
 
 
@@ -88,6 +93,7 @@ def derive_installed_runtime_paths(
         "tools_root": tools_root,
         "dslx_stdlib_root": tools_root / "xls" / "dslx" / "stdlib",
         "libxls": tools_root / libxls_name_for_platform(sys_platform),
+        "xls_aot_runtime": tools_root / static_aot_runtime_name(),
     }
 
 
@@ -112,6 +118,7 @@ def resolve_artifact_plan(
     local_dslx_stdlib_path = "",
     local_driver_path = "",
     local_libxls_path = "",
+    local_xls_aot_runtime_path = "",
     exists_fn = os.path.exists,
 ):
     if surface not in ("runtime", "toolchain"):
@@ -136,6 +143,7 @@ def resolve_artifact_plan(
             "tools_root": Path(local_tools_path),
             "dslx_stdlib_root": Path(local_dslx_stdlib_path),
             "libxls": Path(local_libxls_path),
+            "xls_aot_runtime": Path(local_xls_aot_runtime_path) if local_xls_aot_runtime_path else None,
         }
         if include_driver:
             plan["driver"] = Path(local_driver_path)
@@ -147,7 +155,13 @@ def resolve_artifact_plan(
         raise ValueError("{} requires xls_version".format(artifact_source))
     if include_driver and not driver_version:
         raise ValueError("{} toolchain surface requires xlsynth_driver_version".format(artifact_source))
-    if local_tools_path or local_dslx_stdlib_path or local_driver_path or local_libxls_path:
+    if (
+        local_tools_path
+        or local_dslx_stdlib_path
+        or local_driver_path
+        or local_libxls_path
+        or local_xls_aot_runtime_path
+    ):
         raise ValueError("{} does not accept local_paths attrs".format(artifact_source))
     if artifact_source == "download_only":
         if installed_tools_root_prefix or installed_driver_root_prefix:
@@ -182,13 +196,22 @@ def resolve_artifact_plan(
             plan["driver_version"] = normalize_version(driver_version)
         return plan
 
-    installed_paths_present = all(exists_fn(str(path)) for path in installed_paths.values())
+    installed_paths_present = all(
+        exists_fn(str(path))
+        for name, path in installed_paths.items()
+        if name != "xls_aot_runtime"
+    )
     if artifact_source == "auto" and installed_paths_present:
         plan = {
             "mode": "installed",
             "tools_root": installed_paths["tools_root"],
             "dslx_stdlib_root": installed_paths["dslx_stdlib_root"],
             "libxls": installed_paths["libxls"],
+            "xls_aot_runtime": (
+                installed_paths["xls_aot_runtime"]
+                if exists_fn(str(installed_paths["xls_aot_runtime"]))
+                else None
+            ),
         }
         if include_driver:
             plan["driver"] = installed_paths["driver"]
@@ -206,6 +229,11 @@ def resolve_artifact_plan(
             "tools_root": installed_paths["tools_root"],
             "dslx_stdlib_root": installed_paths["dslx_stdlib_root"],
             "libxls": installed_paths["libxls"],
+            "xls_aot_runtime": (
+                installed_paths["xls_aot_runtime"]
+                if exists_fn(str(installed_paths["xls_aot_runtime"]))
+                else None
+            ),
         }
         if include_driver:
             plan["driver"] = installed_paths["driver"]
@@ -697,10 +725,19 @@ def resolve_downloaded_artifacts(download_root):
     libxls_candidates = sorted(download_root.glob("libxls-*.so")) + sorted(download_root.glob("libxls-*.dylib"))
     if len(libxls_candidates) != 1:
         raise RuntimeError("Expected exactly one libxls artifact in {}, found {}".format(download_root, libxls_candidates))
+    static_aot_runtime_candidates = sorted(download_root.glob("libxls_aot_runtime-*.a"))
+    if len(static_aot_runtime_candidates) > 1:
+        raise RuntimeError(
+            "Expected at most one libxls_aot_runtime artifact in {}, found {}".format(
+                download_root,
+                static_aot_runtime_candidates,
+            )
+        )
     return {
         "tools_root": download_root,
         "dslx_stdlib_root": stdlib_root,
         "libxls": libxls_candidates[0],
+        "xls_aot_runtime": static_aot_runtime_candidates[0] if static_aot_runtime_candidates else None,
         "runtime_files": load_runtime_manifest(download_root),
     }
 
@@ -740,22 +777,25 @@ def resolve_materialization_inputs(repo_root, plan):
     return resolved
 
 
-def write_artifact_config(repo_root, libxls_dest):
+def write_artifact_config(repo_root, libxls_dest, xls_aot_runtime_dest):
     artifact_config_path = repo_root / "xlsynth_artifact_config.toml"
-    artifact_config_path.write_text(
-        "".join([
-            "dso_path = \"{}\"\n".format(libxls_dest.name),
-            "dslx_stdlib_path = \".\"\n",
-        ]),
-        encoding = "utf-8",
-    )
+    config_lines = [
+        "dso_path = \"{}\"\n".format(libxls_dest.name),
+        "dslx_stdlib_path = \".\"\n",
+    ]
+    if xls_aot_runtime_dest is not None:
+        config_lines.append("aot_runtime_path = \"{}\"\n".format(xls_aot_runtime_dest.name))
+    artifact_config_path.write_text("".join(config_lines), encoding = "utf-8")
 
 
-def write_runtime_metadata(repo_root, libxls_dest, runtime_aliases, runtime_files):
+def write_runtime_metadata(repo_root, libxls_dest, xls_aot_runtime_dest, runtime_aliases, runtime_files):
     metadata_path = repo_root / "runtime_metadata.txt"
     metadata_path.write_text(
         "".join([
             "libxls_name={}\n".format(libxls_dest.name),
+            "xls_aot_runtime_name={}\n".format(
+                xls_aot_runtime_dest.name if xls_aot_runtime_dest is not None else "",
+            ),
             "libxls_runtime_aliases={}\n".format(",".join(runtime_aliases)),
             "libxls_runtime_files={}\n".format(",".join(sorted(runtime_files))),
         ]),
@@ -783,6 +823,10 @@ def stage_runtime_payload(repo_root, resolved):
 
     libxls_dest = repo_root / normalized_libxls_name(resolved["libxls"])
     copy_path(resolved["libxls"], libxls_dest)
+    xls_aot_runtime_dest = None
+    if resolved.get("xls_aot_runtime") is not None:
+        xls_aot_runtime_dest = repo_root / static_aot_runtime_name()
+        copy_path(resolved["xls_aot_runtime"], xls_aot_runtime_dest)
 
     staged_runtime_files = []
     for runtime_file in resolved.get("runtime_files", []):
@@ -792,10 +836,17 @@ def stage_runtime_payload(repo_root, resolved):
             staged_runtime_files.append(runtime_dest.name)
 
     runtime_aliases = normalize_runtime_library_identity(libxls_dest)
-    write_artifact_config(repo_root, libxls_dest)
-    write_runtime_metadata(repo_root, libxls_dest, runtime_aliases, staged_runtime_files)
+    write_artifact_config(repo_root, libxls_dest, xls_aot_runtime_dest)
+    write_runtime_metadata(
+        repo_root,
+        libxls_dest,
+        xls_aot_runtime_dest,
+        runtime_aliases,
+        staged_runtime_files,
+    )
     return {
         "libxls_dest": libxls_dest,
+        "xls_aot_runtime_dest": xls_aot_runtime_dest,
         "runtime_aliases": runtime_aliases,
         "runtime_files": staged_runtime_files,
     }
@@ -924,6 +975,7 @@ def parse_args(argv):
     parser.add_argument("--driver-runtime-libxls", default = "")
     parser.add_argument("--driver-runtime-stdlib", default = "")
     parser.add_argument("--rustup-path", default = "")
+    parser.add_argument("--local-xls-aot-runtime-path", default = "")
     return parser.parse_args(argv)
 
 
@@ -961,6 +1013,7 @@ def main(argv):
         local_dslx_stdlib_path = args.local_dslx_stdlib_path,
         local_driver_path = args.local_driver_path,
         local_libxls_path = args.local_libxls_path,
+        local_xls_aot_runtime_path = args.local_xls_aot_runtime_path,
     )
     if args.surface == "runtime":
         materialize_runtime_surface(repo_root, plan)

--- a/xls_toolchain.bzl
+++ b/xls_toolchain.bzl
@@ -19,6 +19,7 @@ XlsArtifactBundleInfo = provider(
         "runtime_library_path": "Directory containing libxls for runtime loading.",
         "tools_root": "The XLS tool root tree artifact.",
         "tools_path": "Directory path containing the XLS tool binaries.",
+        "xls_aot_runtime": "The standalone AOT static runtime archive.",
     },
 )
 
@@ -33,6 +34,7 @@ XlsRuntimeSurfaceInfo = provider(
         "runtime_library_path": "Directory containing libxls for runtime loading.",
         "tools_root": "One XLS tool artifact from the selected tools root.",
         "tools_path": "Directory path containing the XLS tool binaries.",
+        "xls_aot_runtime": "The standalone AOT static runtime archive.",
     },
 )
 
@@ -89,6 +91,7 @@ def _bundle_struct_from_provider(bundle):
         runtime_library_path = bundle.runtime_library_path,
         tools_root = bundle.tools_root,
         tools_path = bundle.tools_path,
+        xls_aot_runtime = bundle.xls_aot_runtime,
     )
 
 def _runtime_struct_from_provider(runtime):
@@ -101,6 +104,7 @@ def _runtime_struct_from_provider(runtime):
         runtime_library_path = runtime.runtime_library_path,
         tools_root = runtime.tools_root,
         tools_path = runtime.tools_path,
+        xls_aot_runtime = runtime.xls_aot_runtime,
     )
 
 def _toolchain_with_semantics(artifact_selection, ctx):
@@ -163,8 +167,10 @@ def _xls_runtime_surface_impl(ctx):
     tool_files = ctx.attr.tools_root[DefaultInfo].files.to_list()
     dslx_stdlib = _single_directory_artifact(ctx.attr.dslx_stdlib, "dslx_stdlib")
     libxls = _single_artifact(ctx.attr.libxls, "libxls")
+    xls_aot_runtime = _single_artifact(ctx.attr.xls_aot_runtime, "xls_aot_runtime") if ctx.attr.xls_aot_runtime else None
     runtime_files = _dedupe_artifacts(ctx.files.runtime_files)
-    artifact_inputs = _dedupe_artifacts(tool_files + [dslx_stdlib] + runtime_files)
+    optional_aot_runtime = [xls_aot_runtime] if xls_aot_runtime else []
+    artifact_inputs = _dedupe_artifacts(tool_files + [dslx_stdlib] + optional_aot_runtime + runtime_files)
     tools_path = _artifact_directory(tool_files, "tools_root")
     return [
         XlsRuntimeSurfaceInfo(
@@ -176,6 +182,7 @@ def _xls_runtime_surface_impl(ctx):
             runtime_library_path = libxls.dirname,
             tools_root = tool_files[0],
             tools_path = tools_path,
+            xls_aot_runtime = xls_aot_runtime,
         ),
         DefaultInfo(files = depset(direct = artifact_inputs)),
     ]
@@ -187,6 +194,7 @@ xls_runtime_surface = rule(
         "libxls": attr.label(allow_files = True, mandatory = True),
         "runtime_files": attr.label_list(allow_files = True),
         "tools_root": attr.label(mandatory = True),
+        "xls_aot_runtime": attr.label(allow_files = True),
     },
 )
 
@@ -320,6 +328,7 @@ def _xls_bundle_impl(ctx):
             runtime_library_path = runtime.runtime_library_path,
             tools_root = runtime.tools_root,
             tools_path = runtime.tools_path,
+            xls_aot_runtime = runtime.xls_aot_runtime,
         ),
         DefaultInfo(files = depset(direct = artifact_inputs)),
     ]
@@ -548,12 +557,25 @@ def _xlsynth_artifact_config_impl(ctx):
     bundle_root = ctx.label.name
     config_output = ctx.actions.declare_file("{}/xlsynth_artifact_config.toml".format(bundle_root))
     dso_output = ctx.actions.declare_file("{}/{}".format(bundle_root, ctx.attr.dso_name))
+    aot_runtime_output = None
+    if ctx.file.static_aot_runtime:
+        aot_runtime_output = ctx.actions.declare_file(
+            "{}/{}".format(bundle_root, ctx.file.static_aot_runtime.basename),
+        )
     stdlib_output = ctx.actions.declare_directory("{}/dslx_stdlib".format(bundle_root))
     dslx_stdlib = _single_directory_artifact(ctx.attr.dslx_stdlib, "dslx_stdlib")
     shared_library = ctx.file.shared_library
+    static_aot_runtime = ctx.file.static_aot_runtime
+    optional_inputs = [static_aot_runtime] if static_aot_runtime else []
+    optional_outputs = [aot_runtime_output] if aot_runtime_output else []
+    optional_arguments = [
+        static_aot_runtime.path,
+        aot_runtime_output.path,
+        static_aot_runtime.basename,
+    ] if static_aot_runtime else ["", "", ""]
     ctx.actions.run_shell(
-        inputs = [dslx_stdlib, shared_library],
-        outputs = [config_output, dso_output, stdlib_output],
+        inputs = [dslx_stdlib, shared_library] + optional_inputs,
+        outputs = [config_output, dso_output, stdlib_output] + optional_outputs,
         arguments = [
             shared_library.path,
             dso_output.path,
@@ -561,7 +583,7 @@ def _xlsynth_artifact_config_impl(ctx):
             stdlib_output.path,
             config_output.path,
             ctx.attr.dso_name,
-        ],
+        ] + optional_arguments,
         command = """
             set -euo pipefail
             shared_library="$1"
@@ -570,16 +592,23 @@ def _xlsynth_artifact_config_impl(ctx):
             stdlib_output="$4"
             config_output="$5"
             dso_name="$6"
+            static_aot_runtime="$7"
+            aot_runtime_output="$8"
+            aot_runtime_name="$9"
 
             mkdir -p "$(dirname "$dso_output")" "$(dirname "$config_output")" "$stdlib_output"
             cp "$shared_library" "$dso_output"
             cp -R "$dslx_stdlib"/. "$stdlib_output"
             printf 'dso_path = "%s"\\ndslx_stdlib_path = "dslx_stdlib"\\n' \
                 "$dso_name" > "$config_output"
+            if [[ -n "$static_aot_runtime" ]]; then
+                cp "$static_aot_runtime" "$aot_runtime_output"
+                printf 'aot_runtime_path = "%s"\\n' "$aot_runtime_name" >> "$config_output"
+            fi
         """,
         progress_message = "Packaging xlsynth artifact config for {}".format(ctx.label),
     )
-    packaged_files = [config_output, dso_output, stdlib_output]
+    packaged_files = [config_output, dso_output, stdlib_output] + optional_outputs
     return DefaultInfo(
         files = depset([config_output]),
         runfiles = ctx.runfiles(files = packaged_files),
@@ -591,6 +620,7 @@ xlsynth_artifact_config = rule(
         "dso_name": attr.string(mandatory = True),
         "dslx_stdlib": attr.label(mandatory = True),
         "shared_library": attr.label(allow_single_file = True, mandatory = True),
+        "static_aot_runtime": attr.label(allow_single_file = True),
     },
 )
 


### PR DESCRIPTION
# Problem Solved
Consumers need a normal bundle surface for the XLS-owned standalone AOT runtime archive after it is released. They should not need to rediscover native artifact filenames or special-case local validation paths.

# What Changed
- Teach bundle materialization and download logic about the optional standalone runtime archive.
- Export the archive through generated runtime repos and artifact config when a bundle publishes it.
- Keep older non-AOT release bundles usable when they do not contain the new archive.
- Add self-tests covering artifact resolution and generated runtime exports.

# Validation
- Existing `rules_xlsynth` self-tests passed for the updated runtime bundle surface.
- The design was validated in downstream carrier proofs on macOS and Ubuntu 24.04 with bundles that expose the archive to real AOT consumers.

# Landing Order
Depends on xlsynth/xlsynth#8. This is the bundle-contract handoff between the XLS producer artifact and downstream public and private consumers.


<!-- spr-stack:start -->
**Stack**:
-   #59
- ➡ #58

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->