### PR TITLE
bundle: export standalone AOT runtime sources for Bazel links

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ The runtime repo exposes:
   `@<name>_runtime//:xls_aot_runtime_link_config_file` when the selected XLS
   line provides the standalone AOT static runtime archive plus its producer-owned
   link metadata
+- `@<name>_runtime//:xls_aot_runtime_source_dep` when the selected XLS line
+  provides the source-backed standalone AOT runtime asset, for Bazel final
+  links that declare native runtime ownership instead of importing the
+  flattened archive
 - `@<name>_runtime//:dslx_stdlib` for packages that need the standard library tree
 - `@<name>_runtime//:xlsynth_sys_artifact_config` for the modern single-file
   build-script contract shared by `xlsynth-sys` and `xlsynth-aot-runtime`
@@ -132,6 +136,24 @@ bundle contract. Older bundles may omit the archive pair entirely; that keeps
 non-AOT consumers on old XLS lines valid while making an AOT consumer fail
 locally if it selects a bundle that cannot provide the runtime artifacts it
 needs.
+
+For direct Cargo linking, `xlsynth-aot-runtime` uses its default native mode
+and requests the released `libxls_aot_runtime.a` archive. For Bazel linking,
+pair `@<name>_runtime//:xls_aot_runtime_source_dep` with
+`XLS_AOT_RUNTIME_LINK_MODE = "declared"` in the crate build-script
+environment:
+
+```text
+Bazel target
+  -> depends on @<name>_runtime//:xls_aot_runtime_source_dep
+  -> depends on xlsynth-aot-runtime configured with declared link mode
+
+xlsynth-aot-runtime
+  -> emits no native runtime archive link request
+```
+
+Declared link mode changes only which build graph supplies the native runtime
+symbols; it does not change standalone AOT runtime execution.
 
 Supported DSLX rules may opt out of the registered default bundle with
 `xls_bundle = "@<name>_toolchain//:bundle"`. Today that escape hatch is available on

--- a/artifact_resolution_test.py
+++ b/artifact_resolution_test.py
@@ -3,6 +3,7 @@
 import os
 from pathlib import Path
 import sys
+import tarfile
 import tempfile
 import unittest
 from unittest import mock
@@ -70,6 +71,7 @@ class ArtifactResolutionTest(unittest.TestCase):
                 "/tools/xlsynth/v0.38.0/libxls.dylib" if sys.platform == "darwin" else "/tools/xlsynth/v0.38.0/libxls.so",
                 "/tools/xlsynth/v0.38.0/libxls_aot_runtime.a",
                 "/tools/xlsynth/v0.38.0/libxls_aot_runtime_link.toml",
+                "/tools/xlsynth/v0.38.0/xls-aot-runtime-source.tar.gz",
             ],
         )
 
@@ -132,6 +134,19 @@ class ArtifactResolutionTest(unittest.TestCase):
         )
         self.assertEqual(plan["mode"], "download")
         self.assertEqual(observed_paths, [])
+
+    def test_download_only_can_use_local_aot_runtime_source(self):
+        plan = materialize_xls_bundle.resolve_artifact_plan(
+            artifact_source = "download_only",
+            xls_version = "0.38.0",
+            driver_version = "0.33.0",
+            local_xls_aot_runtime_source_path = "/tmp/review/xls-aot-runtime-source.tar.gz",
+        )
+        self.assertEqual(plan["mode"], "download")
+        self.assertEqual(
+            plan["xls_aot_runtime_source"],
+            Path("/tmp/review/xls-aot-runtime-source.tar.gz"),
+        )
 
     def test_local_paths_bypass_versioned_selection(self):
         plan = materialize_xls_bundle.resolve_artifact_plan(
@@ -340,6 +355,10 @@ printf 'fallback body\\n'
             plan["xls_aot_runtime_link_config"].name,
             "libxls_aot_runtime_link.toml",
         )
+        self.assertEqual(
+            plan["xls_aot_runtime_source"].name,
+            "xls-aot-runtime-source.tar.gz",
+        )
 
     def test_build_driver_environment_sets_runtime_library_search_path(self):
         libxls_path = "/tmp/xls-bundle/libxls.dylib" if sys.platform == "darwin" else "/tmp/xls-bundle/libxls.so"
@@ -450,6 +469,7 @@ printf 'fallback body\\n'
             (download_root / "libxls-v0.38.0-arm64.dylib").write_text("", encoding = "utf-8")
             (download_root / "libxls_aot_runtime-arm64.a").write_text("", encoding = "utf-8")
             (download_root / "libxls_aot_runtime_link-arm64.toml").write_text("", encoding = "utf-8")
+            (download_root / "xls-aot-runtime-source.tar.gz").write_text("", encoding = "utf-8")
 
             with mock.patch.object(materialize_xls_bundle, "detect_host_platform", return_value = "arm64"):
                 with mock.patch.object(materialize_xls_bundle.subprocess, "run") as mock_run:
@@ -468,6 +488,10 @@ printf 'fallback body\\n'
             self.assertEqual(
                 resolved["xls_aot_runtime_link_config"],
                 download_root / "libxls_aot_runtime_link-arm64.toml",
+            )
+            self.assertEqual(
+                resolved["xls_aot_runtime_source"],
+                download_root / "xls-aot-runtime-source.tar.gz",
             )
             self.assertEqual(resolved["runtime_files"], [])
             mock_run.assert_not_called()
@@ -488,6 +512,7 @@ printf 'fallback body\\n'
 
             self.assertIsNone(resolved["xls_aot_runtime"])
             self.assertIsNone(resolved["xls_aot_runtime_link_config"])
+            self.assertIsNone(resolved["xls_aot_runtime_source"])
             mock_run.assert_not_called()
 
     def test_load_runtime_manifest_returns_runtime_files(self):
@@ -658,6 +683,15 @@ Tag        Type                         Name/Value
             xls_aot_runtime_path.write_text("aot\n", encoding = "utf-8")
             xls_aot_runtime_link_config_path = input_root / "libxls_aot_runtime_link.toml"
             xls_aot_runtime_link_config_path.write_text("format_version = 1\n", encoding = "utf-8")
+            source_repo_root = input_root / "source_repo"
+            source_repo_root.mkdir()
+            (source_repo_root / "BUILD.bazel").write_text(
+                'alias(name = "standalone_aot_runtime", actual = "//:dummy")\n',
+                encoding = "utf-8",
+            )
+            xls_aot_runtime_source_path = input_root / "xls-aot-runtime-source.tar.gz"
+            with tarfile.open(xls_aot_runtime_source_path, "w:gz") as archive:
+                archive.add(source_repo_root / "BUILD.bazel", arcname = "BUILD.bazel")
             runtime_companion = input_root / "libc++.so.1"
             runtime_companion.write_text("runtime\n", encoding = "utf-8")
 
@@ -674,6 +708,7 @@ Tag        Type                         Name/Value
                         "libxls": libxls_path,
                         "xls_aot_runtime": xls_aot_runtime_path,
                         "xls_aot_runtime_link_config": xls_aot_runtime_link_config_path,
+                        "xls_aot_runtime_source": xls_aot_runtime_source_path,
                         "runtime_files": [runtime_companion],
                     },
                 )
@@ -692,6 +727,7 @@ Tag        Type                         Name/Value
                 metadata["xls_aot_runtime_link_config_name"],
                 "libxls_aot_runtime_link.toml",
             )
+            self.assertEqual(metadata["xls_aot_runtime_source_repo"], "xls_aot_runtime_source")
             self.assertEqual(metadata["libxls_runtime_aliases"], "libxls-v0.38.0.so")
             self.assertEqual(metadata["libxls_runtime_files"], "libc++.so.1")
             self.assertIn('aot_runtime_path = "libxls_aot_runtime.a"', artifact_config)
@@ -701,6 +737,7 @@ Tag        Type                         Name/Value
             )
             self.assertTrue((repo_root / "libxls_aot_runtime.a").is_file())
             self.assertTrue((repo_root / "libxls_aot_runtime_link.toml").is_file())
+            self.assertTrue((repo_root / "xls_aot_runtime_source" / "BUILD.bazel").is_file())
             self.assertTrue((repo_root / "libc++.so.1").is_file())
 
     def test_materialize_toolchain_surface_records_driver_capabilities(self):

--- a/download_release.py
+++ b/download_release.py
@@ -64,6 +64,10 @@ def build_static_aot_runtime_link_config_release_filename(platform):
     return "libxls_aot_runtime_link-{}.toml".format(platform)
 
 
+def build_static_aot_runtime_source_release_filename():
+    return "xls-aot-runtime-source.tar.gz"
+
+
 def build_runtime_tarball_release_filename(platform):
     return "libxls-runtime-{}.tar.gz".format(platform)
 
@@ -292,6 +296,13 @@ def main():
                 partial_path = os.path.join(options.output_dir, partial_name)
                 if os.path.exists(partial_path):
                     os.remove(partial_path)
+        try_high_integrity_download(
+            base_url,
+            build_static_aot_runtime_source_release_filename(),
+            options.output_dir,
+            options.max_attempts,
+            is_binary = False,
+        )
 
     # Download and extract dslx_stdlib.tar.gz
     stdlib_filename = "dslx_stdlib.tar.gz"

--- a/download_release_test.py
+++ b/download_release_test.py
@@ -89,6 +89,10 @@ class DownloadReleaseTest(unittest.TestCase):
             download_release.build_static_aot_runtime_link_config_release_filename("ubuntu2004"),
             "libxls_aot_runtime_link-ubuntu2004.toml",
         )
+        self.assertEqual(
+            download_release.build_static_aot_runtime_source_release_filename(),
+            "xls-aot-runtime-source.tar.gz",
+        )
 
     def test_copy_url_to_path_retries_after_stream_reset(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -80,6 +80,7 @@ def _runtime_build_file(
         libxls_name,
         xls_aot_runtime_name,
         xls_aot_runtime_link_config_name,
+        xls_aot_runtime_source_repo,
         runtime_files,
         runtime_aliases):
     tool_list = ",\n        ".join(['"{}"'.format(name) for name in _TOOL_BINARIES])
@@ -111,6 +112,15 @@ cc_import(
         xls_aot_runtime_name = xls_aot_runtime_name,
         xls_aot_runtime_link_config_name = xls_aot_runtime_link_config_name,
     ) if xls_aot_runtime_name else ""
+    aot_runtime_source_rule = """
+alias(
+    name = "xls_aot_runtime_source_dep",
+    actual = "//{xls_aot_runtime_source_repo}:standalone_aot_runtime",
+    visibility = ["//visibility:public"],
+)
+""".format(
+        xls_aot_runtime_source_repo = xls_aot_runtime_source_repo,
+    ) if xls_aot_runtime_source_repo else ""
     lib_file_rule = """
 filegroup(
     name = "libxls_file",
@@ -163,6 +173,7 @@ copy_flat_files_to_directory(
 
 {lib_file_rule}
 {aot_runtime_rule}
+{aot_runtime_source_rule}
 
 xlsynth_artifact_config(
     name = "artifact_config",
@@ -229,6 +240,7 @@ xls_runtime_surface(
         libxls_name = libxls_name,
         lib_file_rule = lib_file_rule.strip(),
         aot_runtime_rule = aot_runtime_rule.strip(),
+        aot_runtime_source_rule = aot_runtime_source_rule.strip(),
         static_aot_runtime = '":xls_aot_runtime_file"' if xls_aot_runtime_name else "None",
         static_aot_runtime_link_config = '":xls_aot_runtime_link_config_file"' if xls_aot_runtime_name else "None",
     )
@@ -388,6 +400,11 @@ def _materialize_bundle_args(repo_ctx, surface):
             "--local-xls-aot-runtime-link-config-path",
             repo_ctx.attr.local_xls_aot_runtime_link_config_path,
         ])
+    if repo_ctx.attr.local_xls_aot_runtime_source_path:
+        args.extend([
+            "--local-xls-aot-runtime-source-path",
+            repo_ctx.attr.local_xls_aot_runtime_source_path,
+        ])
     return args
 
 def _runtime_repo_impl(repo_ctx):
@@ -418,6 +435,7 @@ def _runtime_repo_impl(repo_ctx):
             libxls_name = metadata["libxls_name"],
             xls_aot_runtime_name = metadata["xls_aot_runtime_name"],
             xls_aot_runtime_link_config_name = metadata["xls_aot_runtime_link_config_name"],
+            xls_aot_runtime_source_repo = metadata["xls_aot_runtime_source_repo"],
             runtime_files = runtime_files,
             runtime_aliases = runtime_aliases,
         ),
@@ -460,6 +478,7 @@ _runtime_repo_attrs = {
     "local_libxls_path": attr.string(),
     "local_xls_aot_runtime_path": attr.string(),
     "local_xls_aot_runtime_link_config_path": attr.string(),
+    "local_xls_aot_runtime_source_path": attr.string(),
     "local_tools_path": attr.string(),
     "xls_version": attr.string(),
     "xlsynth_driver_version": attr.string(),
@@ -475,6 +494,7 @@ _toolchain_repo_attrs = {
     "local_libxls_path": attr.string(),
     "local_xls_aot_runtime_path": attr.string(),
     "local_xls_aot_runtime_link_config_path": attr.string(),
+    "local_xls_aot_runtime_source_path": attr.string(),
     "local_tools_path": attr.string(),
     "repo_alias": attr.string(mandatory = True),
     "runtime_repo_name": attr.string(mandatory = True),
@@ -519,6 +539,7 @@ _toolchain_tag = tag_class(attrs = {
     "local_libxls_path": attr.string(),
     "local_xls_aot_runtime_path": attr.string(),
     "local_xls_aot_runtime_link_config_path": attr.string(),
+    "local_xls_aot_runtime_source_path": attr.string(),
     "local_tools_path": attr.string(),
     "name": attr.string(mandatory = True),
     "xls_version": attr.string(),
@@ -541,6 +562,7 @@ def _xls_extension_impl(module_ctx):
                 local_libxls_path = toolchain.local_libxls_path,
                 local_xls_aot_runtime_path = toolchain.local_xls_aot_runtime_path,
                 local_xls_aot_runtime_link_config_path = toolchain.local_xls_aot_runtime_link_config_path,
+                local_xls_aot_runtime_source_path = toolchain.local_xls_aot_runtime_source_path,
                 local_tools_path = toolchain.local_tools_path,
                 xls_version = toolchain.xls_version,
                 xlsynth_driver_version = toolchain.xlsynth_driver_version,
@@ -561,6 +583,7 @@ def _xls_extension_impl(module_ctx):
                 local_libxls_path = toolchain.local_libxls_path,
                 local_xls_aot_runtime_path = toolchain.local_xls_aot_runtime_path,
                 local_xls_aot_runtime_link_config_path = toolchain.local_xls_aot_runtime_link_config_path,
+                local_xls_aot_runtime_source_path = toolchain.local_xls_aot_runtime_source_path,
                 local_tools_path = toolchain.local_tools_path,
                 repo_alias = toolchain_name,
                 runtime_repo_name = runtime_name,

--- a/materialize_xls_bundle.py
+++ b/materialize_xls_bundle.py
@@ -69,6 +69,10 @@ def static_aot_runtime_link_config_name():
     return "libxls_aot_runtime_link.toml"
 
 
+def static_aot_runtime_source_name():
+    return "xls-aot-runtime-source.tar.gz"
+
+
 def derive_installed_paths(
         xls_version,
         driver_version,
@@ -85,6 +89,7 @@ def derive_installed_paths(
         "libxls": tools_root / libxls_name_for_platform(sys_platform),
         "xls_aot_runtime": tools_root / static_aot_runtime_name(),
         "xls_aot_runtime_link_config": tools_root / static_aot_runtime_link_config_name(),
+        "xls_aot_runtime_source": tools_root / static_aot_runtime_source_name(),
     }
 
 
@@ -100,6 +105,7 @@ def derive_installed_runtime_paths(
         "libxls": tools_root / libxls_name_for_platform(sys_platform),
         "xls_aot_runtime": tools_root / static_aot_runtime_name(),
         "xls_aot_runtime_link_config": tools_root / static_aot_runtime_link_config_name(),
+        "xls_aot_runtime_source": tools_root / static_aot_runtime_source_name(),
     }
 
 
@@ -126,6 +132,7 @@ def resolve_artifact_plan(
     local_libxls_path = "",
     local_xls_aot_runtime_path = "",
     local_xls_aot_runtime_link_config_path = "",
+    local_xls_aot_runtime_source_path = "",
     exists_fn = os.path.exists,
 ):
     if surface not in ("runtime", "toolchain"):
@@ -159,6 +166,11 @@ def resolve_artifact_plan(
             "xls_aot_runtime_link_config": (
                 Path(local_xls_aot_runtime_link_config_path)
                 if local_xls_aot_runtime_link_config_path
+                else None
+            ),
+            "xls_aot_runtime_source": (
+                Path(local_xls_aot_runtime_source_path)
+                if local_xls_aot_runtime_source_path
                 else None
             ),
         }
@@ -210,6 +222,8 @@ def resolve_artifact_plan(
             "mode": "download",
             "xls_version": normalize_version(xls_version),
         }
+        if local_xls_aot_runtime_source_path:
+            plan["xls_aot_runtime_source"] = Path(local_xls_aot_runtime_source_path)
         if include_driver:
             plan["driver_version"] = normalize_version(driver_version)
         return plan
@@ -217,11 +231,18 @@ def resolve_artifact_plan(
     installed_paths_present = all(
         exists_fn(str(path))
         for name, path in installed_paths.items()
-        if name not in ("xls_aot_runtime", "xls_aot_runtime_link_config")
+        if name not in (
+            "xls_aot_runtime",
+            "xls_aot_runtime_link_config",
+            "xls_aot_runtime_source",
+        )
     )
     installed_aot_runtime_present = exists_fn(str(installed_paths["xls_aot_runtime"]))
     installed_aot_runtime_link_config_present = exists_fn(
         str(installed_paths["xls_aot_runtime_link_config"])
+    )
+    installed_aot_runtime_source_present = exists_fn(
+        str(installed_paths["xls_aot_runtime_source"])
     )
     if installed_aot_runtime_present != installed_aot_runtime_link_config_present:
         raise ValueError(
@@ -244,9 +265,16 @@ def resolve_artifact_plan(
                 if installed_aot_runtime_link_config_present
                 else None
             ),
+            "xls_aot_runtime_source": (
+                installed_paths["xls_aot_runtime_source"]
+                if installed_aot_runtime_source_present
+                else None
+            ),
         }
         if include_driver:
             plan["driver"] = installed_paths["driver"]
+        if local_xls_aot_runtime_source_path:
+            plan["xls_aot_runtime_source"] = Path(local_xls_aot_runtime_source_path)
         return plan
     if artifact_source == "installed_only":
         if not installed_paths_present:
@@ -271,14 +299,23 @@ def resolve_artifact_plan(
                 if installed_aot_runtime_link_config_present
                 else None
             ),
+            "xls_aot_runtime_source": (
+                installed_paths["xls_aot_runtime_source"]
+                if installed_aot_runtime_source_present
+                else None
+            ),
         }
         if include_driver:
             plan["driver"] = installed_paths["driver"]
+        if local_xls_aot_runtime_source_path:
+            plan["xls_aot_runtime_source"] = Path(local_xls_aot_runtime_source_path)
         return plan
     plan = {
         "mode": "download",
         "xls_version": normalize_version(xls_version),
     }
+    if local_xls_aot_runtime_source_path:
+        plan["xls_aot_runtime_source"] = Path(local_xls_aot_runtime_source_path)
     if include_driver:
         plan["driver_version"] = normalize_version(driver_version)
     return plan
@@ -786,6 +823,7 @@ def resolve_downloaded_artifacts(download_root):
                 download_root
             )
         )
+    static_aot_runtime_source = download_root / static_aot_runtime_source_name()
     return {
         "tools_root": download_root,
         "dslx_stdlib_root": stdlib_root,
@@ -794,6 +832,11 @@ def resolve_downloaded_artifacts(download_root):
         "xls_aot_runtime_link_config": (
             static_aot_runtime_link_config_candidates[0]
             if static_aot_runtime_link_config_candidates
+            else None
+        ),
+        "xls_aot_runtime_source": (
+            static_aot_runtime_source
+            if static_aot_runtime_source.exists()
             else None
         ),
         "runtime_files": load_runtime_manifest(download_root),
@@ -828,7 +871,10 @@ def download_versioned_artifacts(repo_root, xls_version):
 
 def resolve_materialization_inputs(repo_root, plan):
     if plan["mode"] == "download":
-        return download_versioned_artifacts(repo_root, plan["xls_version"])
+        resolved = download_versioned_artifacts(repo_root, plan["xls_version"])
+        if plan.get("xls_aot_runtime_source") is not None:
+            resolved["xls_aot_runtime_source"] = plan["xls_aot_runtime_source"]
+        return resolved
     resolved = dict(plan)
     validate_stdlib_root(resolved["dslx_stdlib_root"])
     resolved["runtime_files"] = load_runtime_manifest(Path(resolved["libxls"]).parent)
@@ -861,6 +907,7 @@ def write_runtime_metadata(
         libxls_dest,
         xls_aot_runtime_dest,
         xls_aot_runtime_link_config_dest,
+        xls_aot_runtime_source_repo,
         runtime_aliases,
         runtime_files,
 ):
@@ -874,6 +921,11 @@ def write_runtime_metadata(
             "xls_aot_runtime_link_config_name={}\n".format(
                 xls_aot_runtime_link_config_dest.name
                 if xls_aot_runtime_link_config_dest is not None
+                else "",
+            ),
+            "xls_aot_runtime_source_repo={}\n".format(
+                xls_aot_runtime_source_repo.name
+                if xls_aot_runtime_source_repo is not None
                 else "",
             ),
             "libxls_runtime_aliases={}\n".format(",".join(runtime_aliases)),
@@ -913,6 +965,20 @@ def stage_runtime_payload(repo_root, resolved):
             resolved["xls_aot_runtime_link_config"],
             xls_aot_runtime_link_config_dest,
         )
+    xls_aot_runtime_source_repo = None
+    if resolved.get("xls_aot_runtime_source") is not None:
+        xls_aot_runtime_source_repo = repo_root / "xls_aot_runtime_source"
+        ensure_clean_path(xls_aot_runtime_source_repo)
+        shutil.unpack_archive(
+            str(resolved["xls_aot_runtime_source"]),
+            str(xls_aot_runtime_source_repo),
+        )
+        if not (xls_aot_runtime_source_repo / "BUILD.bazel").is_file():
+            raise ValueError(
+                "Standalone AOT runtime source archive must unpack BUILD.bazel at {}".format(
+                    xls_aot_runtime_source_repo,
+                )
+            )
 
     staged_runtime_files = []
     for runtime_file in resolved.get("runtime_files", []):
@@ -933,6 +999,7 @@ def stage_runtime_payload(repo_root, resolved):
         libxls_dest,
         xls_aot_runtime_dest,
         xls_aot_runtime_link_config_dest,
+        xls_aot_runtime_source_repo,
         runtime_aliases,
         staged_runtime_files,
     )
@@ -940,6 +1007,7 @@ def stage_runtime_payload(repo_root, resolved):
         "libxls_dest": libxls_dest,
         "xls_aot_runtime_dest": xls_aot_runtime_dest,
         "xls_aot_runtime_link_config_dest": xls_aot_runtime_link_config_dest,
+        "xls_aot_runtime_source_repo": xls_aot_runtime_source_repo,
         "runtime_aliases": runtime_aliases,
         "runtime_files": staged_runtime_files,
     }
@@ -1070,6 +1138,7 @@ def parse_args(argv):
     parser.add_argument("--rustup-path", default = "")
     parser.add_argument("--local-xls-aot-runtime-path", default = "")
     parser.add_argument("--local-xls-aot-runtime-link-config-path", default = "")
+    parser.add_argument("--local-xls-aot-runtime-source-path", default = "")
     return parser.parse_args(argv)
 
 
@@ -1109,6 +1178,7 @@ def main(argv):
         local_libxls_path = args.local_libxls_path,
         local_xls_aot_runtime_path = args.local_xls_aot_runtime_path,
         local_xls_aot_runtime_link_config_path = args.local_xls_aot_runtime_link_config_path,
+        local_xls_aot_runtime_source_path = args.local_xls_aot_runtime_source_path,
     )
     if args.surface == "runtime":
         materialize_runtime_surface(repo_root, plan)


### PR DESCRIPTION
This change makes the XLS runtime bundle expose the producer-published standalone AOT runtime source target when the selected XLS release includes it. Bazel consumers can depend on `@<name>_runtime//:xls_aot_runtime_source_dep` while older release lanes that do not carry the optional source asset still materialize normally.

# Problem Solved

The runtime bundle currently exports the flattened standalone archive for downstream native links. That archive is still useful for direct consumers, but a mixed Bazel final link needs a declared source dependency so Bazel owns the native link closure instead of importing a flattened archive with bundled native dependencies.

Minimized example:

```text
selected XLS release has source asset
  @default_xls_runtime//:xls_aot_runtime_source_dep
    -> aliases the producer source target

older XLS release has no source asset
  runtime bundle still loads
  no source dependency is exported
```

# What Changed

- Download and materialize `xls-aot-runtime-source.tar.gz` beside the selected XLS runtime payload when it exists.
- Unpack that producer-owned source repo into the generated runtime repository and export a public `:xls_aot_runtime_source_dep` alias.
- Add local-source override plumbing for review and staged rollout proofs.
- Keep the source payload optional so old and frozen lanes without the asset do not stop non-AOT consumers from loading the bundle.

# Validation

- `bazel test //:artifact_resolution_test //:download_release_test //:external_bundle_exports_test`