### PR TITLE
bundle: provide verified producer identity for structural IDs

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_python//python:defs.bzl", "py_test")
+load("//:trusted_identity_boundary_test.bzl", "trusted_identity_boundary_test_suite")
 
 py_test(
     name = "make_env_helpers_test",
@@ -32,6 +33,10 @@ py_test(
         "download_release.py",
         "download_release_test.py",
     ],
+)
+
+trusted_identity_boundary_test_suite(
+    name = "trusted_identity_boundary_test",
 )
 
 genrule(
@@ -79,11 +84,30 @@ genrule(
     cmd = "printf '%s\\n' '$(locations @rules_xlsynth_selftest_xls_runtime//:xlsynth_sys_legacy_dso)' '$(locations @rules_xlsynth_selftest_xls_runtime//:xlsynth_sys_legacy_stdlib)' > $@",
 )
 
+genrule(
+    name = "resolved_identity_probe",
+    srcs = ["@rules_xlsynth_selftest_xls_toolchain"],
+    outs = ["resolved_identity_location.txt"],
+    cmd = """
+set -e
+for path in $(locations @rules_xlsynth_selftest_xls_toolchain//:rules_xlsynth_selftest_xls_toolchain); do
+  case "$$path" in
+    *xlsynth-driver.resolved_identity.json)
+      printf '%s\\n' "$$path" > "$@"
+      exit 0
+      ;;
+  esac
+done
+exit 1
+""",
+)
+
 py_test(
     name = "external_bundle_exports_test",
     srcs = ["external_bundle_exports_test.py"],
     data = [
         ":bundle_alias_probe",
+        ":resolved_identity_probe",
         ":stdlib_location_probe",
         ":xlsynth_sys_artifact_config_probe",
         ":xlsynth_sys_dep_probe",

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -83,6 +83,49 @@ needed only by driver-backed actions. This lets runtime consumers depend on
 `@<name>_runtime` or register `@<name>_toolchain` without materializing,
 probing, downloading, or compiling `xlsynth-driver`.
 
+## Resolved producer identity
+
+Consumers that mint durable identities can set `emit_resolved_identity = True`.
+The runtime repository creates `resolved_identity.json` as a private input
+visible only to its paired generated toolchain repository. Public runtime
+providers do not carry identity. The generated driver action validates its
+selected `xlsynth-crate` pin and the manifest's internal pin relationships,
+then emits the identity sidecar exported by the bundle. Consumers receive
+producer identity only through `XlsArtifactBundleInfo`, which keeps the
+executed bundle and its producer identity in one Bazel-owned handoff instead of
+asking a downstream action to restate or pair identity separately.
+Identity-bearing driver targets are valid only at the generated root targets in
+the canonical paired `*_runtime` and `*_toolchain` repositories. This rejects
+hand-written public-rule assembly before action execution.
+
+The manifest records typed `xlsynth-crate` and XLS pins, exact resolved source
+revisions, the published XLS release used for artifacts, and the XLS release
+implied by the selected crate's `xlsynth-sys/build.rs`. Crate releases and XLS
+releases are independently versioned; matching version text is not a binding
+rule. By default, identity materialization rejects an explicit XLS pin that
+does not resolve to the crate-implied XLS release.
+`allow_xls_pin_mismatch = True` is reserved for deliberate development
+overrides. Trusted identity emission requires `artifact_source =
+"download_only"`: the installed-layout modes intentionally trust
+consumer-owned directories and therefore cannot mint an authoritative archive
+identity. It also rejects `local_xls_aot_runtime_source_path`, because those
+source bytes are not covered by the resolved XLS identity.
+
+An exact `xlsynth_driver_git_revision` is materialized by Cargo
+`--git ... --rev <SHA>`. Reusing an installed Git-pinned driver additionally
+requires an adjacent provenance record that binds the canonical source
+repository, exact revision, and driver digest. `auto` reinstalls if that proof
+is missing or stale, while `installed_only` fails. An exact `xls_git_revision`
+reuses published release artifacts only when the SHA maps to one published XLS
+release tag. Building arbitrary XLS source revisions is intentionally outside
+this contract. `local_paths` remains useful for non-provenance-sensitive
+development but cannot emit trusted resolved identity.
+
+The trusted handoff assumes the consumer controls the selected
+`rules_xlsynth` source and module graph. It is not cryptographic attestation
+against a root module that replaces `rules_xlsynth`, overrides generated
+repositories, or deliberately constructs a lying fork.
+
 ## Default bundles and explicit overrides
 
 Most rules use the registered default workspace bundle through normal Bazel

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,23 +5,25 @@ bazel_dep(name = "rules_cc", version = "0.2.11")
 bazel_dep(name = "rules_python", version = "1.0.0")
 
 xls = use_extension("//:extensions.bzl", "xls", dev_dependency = True)
-
 xls.toolchain(
     name = "rules_xlsynth_selftest_xls",
+    # Exercise the explicit development override: crate v0.36.0 implies XLS
+    # v0.39.0, while the existing self-test intentionally selects XLS v0.40.0.
+    allow_xls_pin_mismatch = True,
+    artifact_source = "download_only",
+    emit_resolved_identity = True,
     xls_version = "0.40.0",
     xlsynth_driver_version = "0.36.0",
-    artifact_source = "download_only",
 )
 
 # Mirror the explicit override repo name used by the standalone smoke example
 # so `bazel test //...` from the repo root can still analyze that package.
 xls.toolchain(
     name = "workspace_override_xls",
+    artifact_source = "download_only",
     xls_version = "0.40.0",
     xlsynth_driver_version = "0.36.0",
-    artifact_source = "download_only",
 )
-
 use_repo(
     xls,
     "rules_xlsynth_selftest_xls_runtime",
@@ -29,6 +31,7 @@ use_repo(
     "workspace_override_xls_runtime",
     "workspace_override_xls_toolchain",
 )
+
 register_toolchains(
     "@rules_xlsynth_selftest_xls_toolchain//:all",
     dev_dependency = True,

--- a/README.md
+++ b/README.md
@@ -64,16 +64,56 @@ are resolved at different times:
 - The runtime repo for `local_paths` requires `local_tools_path`,
   `local_dslx_stdlib_path`, and `local_libxls_path`. `local_driver_path` is
   required only when a driver-backed bundle/action is built.
-- The runtime repo for `auto` and `installed_only` requires `xls_version` and
-  `installed_tools_root_prefix`. `xlsynth_driver_version` and
-  `installed_driver_root_prefix` are required only when a driver-backed
-  bundle/action is built.
-- `download_only` requires `xls_version` for the runtime repo.
-  `xlsynth_driver_version` is required only when the driver action has to
-  install the driver.
+- The runtime repo for `auto` and `installed_only` requires an XLS release pin
+  through `xls_version` and `installed_tools_root_prefix`.
+  `xlsynth_driver_version` and `installed_driver_root_prefix` are required only
+  when a driver-backed bundle/action is built.
+- `download_only` requires exactly one XLS release or Git pin through
+  `xls_version` or `xls_git_revision`. A driver-backed bundle similarly requires
+  exactly one `xlsynth_driver_version` or `xlsynth_driver_git_revision`.
 - `local_paths` does not accept `xls_version` or `xlsynth_driver_version`;
-  the other modes do not accept any `local_*` attrs.
+  the other modes accept no local artifact overrides except
+  `local_xls_aot_runtime_source_path`.
 - `download_only` does not accept any `installed_*` attrs.
+
+For provenance-sensitive consumers, `emit_resolved_identity = True` makes the
+module extension emit `resolved_identity.json` in its generated runtime
+repository. Public `xls_runtime_surface` targets remain non-identity surfaces.
+The generated toolchain passes the same-repository manifest to the lazy driver
+action, which validates it against the exact selected `xlsynth-crate` pin and
+emits the sidecar exposed by the bundle provider. The manifest cannot be
+attached to consumer-owned runtime inputs through the public runtime rule:
+identity-bearing drivers are accepted only at the generated root targets in the
+canonical paired `*_runtime` and `*_toolchain` repositories. Hand-written
+identity-bearing driver targets fail analysis.
+That manifest records typed `xlsynth-crate` and XLS pins, the exact resolved
+source revisions, the published XLS release selected for artifacts, and the XLS
+release implied by `xlsynth-sys/build.rs`. The two release namespaces are
+independent: for example, an `xlsynth-crate` release may select a differently
+numbered XLS release. Identity-capable bundles validate the implied and explicit
+XLS releases by default; `allow_xls_pin_mismatch = True` is an explicit
+development override. Trusted identity emission requires
+`artifact_source = "download_only"` so the bundle cannot silently reuse
+consumer-owned installed or local artifacts. It also rejects
+`local_xls_aot_runtime_source_path`, because those source bytes are not covered
+by the resolved XLS identity.
+
+Identity-capable bundles may use `xlsynth_driver_git_revision = "<40-char SHA>"`
+instead of `xlsynth_driver_version`; the lazy driver action then installs with
+Cargo `--git ... --rev <SHA>`. Reusing an installed Git-pinned driver requires
+an adjacent `xlsynth-driver.provenance.json` that binds the canonical source
+repository, exact revision, and driver digest. `auto` reinstalls when that
+proof is absent or stale; `installed_only` reports an error. They may use
+`xls_git_revision = "<40-char SHA>"` instead of `xls_version` only when that
+exact XLS SHA maps to one published `xlsynth/xlsynth` release tag. `local_paths`
+bundles remain available for local development but cannot emit trusted resolved
+identity.
+
+This is a Bazel graph-integrity boundary, not a cryptographic attestation
+against a consumer that replaces `rules_xlsynth`, overrides an
+extension-generated repository, or otherwise controls the trusted module graph.
+Provenance-sensitive consumers must pin and control the `rules_xlsynth` source
+and generated module configuration, as Auto-SPO does.
 
 Registering or loading `@<name>_toolchain` is metadata-only: it defines the
 toolchain, bundle, and `xlsynth-driver` targets, but does not copy, execute,

--- a/artifact_resolution_test.py
+++ b/artifact_resolution_test.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import os
 from pathlib import Path
 import sys
@@ -207,7 +208,7 @@ class ArtifactResolutionTest(unittest.TestCase):
             installed_driver_root_prefix = "/tools/xlsynth-driver",
             exists_fn = lambda path: True,
         )
-        self.assertEqual(plan["mode"], "installed")
+        self.assertEqual(plan["mode"], "auto_installed")
         self.assertEqual(plan["driver"], Path("/tools/xlsynth-driver/0.33.0/bin/xlsynth-driver"))
 
     def test_resolve_driver_plan_auto_falls_back_to_download(self):
@@ -309,17 +310,30 @@ printf 'fallback body\\n'
             fallback_driver.chmod(0o755)
 
             output_driver = root / "out" / "xlsynth-driver"
-            materialize_xls_bundle.materialize_driver_binary(
-                repo_root = root / "repo",
-                plan = {
-                    "mode": "auto_driver_input",
-                    "driver": declared_driver,
-                    "driver_version": "0.33.0",
-                    "installed_driver_root_prefix": str(root / "installed"),
-                },
-                driver_output = output_driver,
-                libxls_path = root / "runtime" / "libxls.so",
-                dslx_stdlib_path = root / "stdlib",
+            with mock.patch.object(
+                materialize_xls_bundle,
+                "install_driver",
+                return_value = fallback_driver,
+            ) as mock_install:
+                materialize_xls_bundle.materialize_driver_binary(
+                    repo_root = root / "repo",
+                    plan = {
+                        "mode": "auto_driver_input",
+                        "driver": declared_driver,
+                        "driver_version": "0.33.0",
+                        "installed_driver_root_prefix": str(root / "installed"),
+                    },
+                    driver_output = output_driver,
+                    libxls_path = root / "runtime" / "libxls.so",
+                    dslx_stdlib_path = root / "stdlib",
+                )
+            mock_install.assert_called_once_with(
+                root / "repo",
+                "0.33.0",
+                root / "runtime" / "libxls.so",
+                root / "stdlib",
+                rustup_path = "",
+                driver_git_revision = "",
             )
             self.assertIn("fallback body", output_driver.read_text(encoding = "utf-8"))
 
@@ -423,6 +437,274 @@ printf 'fallback body\\n'
             ],
         )
 
+    def test_build_driver_git_install_command_uses_exact_revision(self):
+        revision = "0910ee19072a39a960b8df85b4f1e25199a4b4be"
+        command = materialize_xls_bundle.build_driver_git_install_command(
+            "/usr/bin/rustup",
+            "/tmp/xls-driver-root",
+            revision,
+        )
+        self.assertEqual(
+            command,
+            [
+                "/usr/bin/rustup",
+                "run",
+                "nightly",
+                "cargo",
+                "install",
+                "--locked",
+                "--root",
+                "/tmp/xls-driver-root",
+                "--git",
+                "https://github.com/xlsynth/xlsynth-crate.git",
+                "--rev",
+                revision,
+                "xlsynth-driver",
+            ],
+        )
+
+    def test_resolve_driver_plan_uses_git_revision_as_installed_layout_key(self):
+        revision = "0910ee19072a39a960b8df85b4f1e25199a4b4be"
+        plan = materialize_xls_bundle.resolve_driver_plan(
+            artifact_source = "auto",
+            driver_version = "",
+            driver_git_revision = revision,
+            installed_driver_root_prefix = "/tools/xlsynth-driver",
+            exists_fn = lambda path: True,
+        )
+        self.assertEqual(plan["mode"], "auto_installed")
+        self.assertEqual(
+            plan["driver"],
+            Path("/tools/xlsynth-driver") / revision / "bin" / "xlsynth-driver",
+        )
+        self.assertEqual(plan["driver_git_revision"], revision)
+
+    def test_resolve_archive_identity_keeps_crate_and_xls_versions_independent(self):
+        crate_revision = "c6a302d21568ce424143d49c1b31b3e14ed70035"
+        xls_revision = "8c5c112b4563401d33b4da1dcd4d7f69db54e0e5"
+        observed_urls = []
+
+        def list_remote_tags(repo_url):
+            if repo_url == "https://github.com/xlsynth/xlsynth-crate.git":
+                return {"v0.50.0": crate_revision}
+            return {"v0.50.1": xls_revision}
+
+        def read_text(url):
+            observed_urls.append(url)
+            return 'const RELEASE_LIB_VERSION_TAG: &str = "v0.50.1";\n'
+
+        identity = materialize_xls_bundle.resolve_archive_identity(
+            xls_version = "0.50.1",
+            xls_git_revision = "",
+            driver_version = "0.50.0",
+            driver_git_revision = "",
+            list_remote_tags_fn = list_remote_tags,
+            read_text_fn = read_text,
+        )
+
+        self.assertEqual(
+            identity,
+            {
+                "schema_version": 1,
+                "xlsynth_crate_pin": {
+                    "kind": "release_tag",
+                    "value": "v0.50.0",
+                },
+                "xls_pin": {
+                    "kind": "release_tag",
+                    "value": "v0.50.1",
+                },
+                "resolved_xlsynth_crate_revision": crate_revision,
+                "crate_implied_xls_release_tag": "v0.50.1",
+                "resolved_xls_release_tag": "v0.50.1",
+                "resolved_xls_revision": xls_revision,
+            },
+        )
+        self.assertEqual(
+            observed_urls,
+            [
+                "https://raw.githubusercontent.com/xlsynth/xlsynth-crate/{}/xlsynth-sys/build.rs".format(
+                    crate_revision,
+                ),
+            ],
+        )
+
+    def test_resolve_archive_identity_accepts_fetchable_crate_git_revision(self):
+        crate_revision = "0910ee19072a39a960b8df85b4f1e25199a4b4be"
+        xls_revision = "8c5c112b4563401d33b4da1dcd4d7f69db54e0e5"
+        observed_urls = []
+
+        def read_text(url):
+            observed_urls.append(url)
+            return 'const RELEASE_LIB_VERSION_TAG: &str = "v0.50.1";\n'
+
+        identity = materialize_xls_bundle.resolve_archive_identity(
+            xls_version = "v0.50.1",
+            xls_git_revision = "",
+            driver_version = "",
+            driver_git_revision = crate_revision,
+            list_remote_tags_fn = lambda _repo_url: {"v0.50.1": xls_revision},
+            read_text_fn = read_text,
+        )
+
+        self.assertEqual(identity["xlsynth_crate_pin"]["kind"], "git_revision")
+        self.assertEqual(identity["resolved_xlsynth_crate_revision"], crate_revision)
+        self.assertEqual(
+            observed_urls,
+            [
+                "https://raw.githubusercontent.com/xlsynth/xlsynth-crate/{}/xlsynth-sys/build.rs".format(
+                    crate_revision,
+                ),
+            ],
+        )
+
+    def test_resolve_archive_identity_rejects_unresolvable_crate_git_revision(self):
+        with self.assertRaisesRegex(ValueError, "could not be resolved"):
+            materialize_xls_bundle.resolve_archive_identity(
+                xls_version = "v0.50.1",
+                xls_git_revision = "",
+                driver_version = "",
+                driver_git_revision = "0910ee19072a39a960b8df85b4f1e25199a4b4be",
+                list_remote_tags_fn = lambda _repo_url: {
+                    "v0.50.1": "8c5c112b4563401d33b4da1dcd4d7f69db54e0e5",
+                },
+                read_text_fn = lambda _url: (_ for _ in ()).throw(OSError("not found")),
+            )
+
+    def test_resolve_archive_identity_maps_xls_git_revision_to_published_release(self):
+        crate_revision = "0910ee19072a39a960b8df85b4f1e25199a4b4be"
+        xls_revision = "8c5c112b4563401d33b4da1dcd4d7f69db54e0e5"
+        identity = materialize_xls_bundle.resolve_archive_identity(
+            xls_version = "",
+            xls_git_revision = xls_revision,
+            driver_version = "",
+            driver_git_revision = crate_revision,
+            list_remote_tags_fn = lambda _repo_url: {"v0.50.1": xls_revision},
+            read_text_fn = lambda _url: 'const RELEASE_LIB_VERSION_TAG: &str = "v0.50.1";\n',
+        )
+
+        self.assertEqual(
+            identity["xls_pin"],
+            {
+                "kind": "git_revision",
+                "value": xls_revision,
+            },
+        )
+        self.assertEqual(identity["resolved_xls_release_tag"], "v0.50.1")
+
+    def test_resolve_archive_identity_rejects_unpublished_xls_git_revision(self):
+        with self.assertRaisesRegex(ValueError, "does not map to a published XLS release tag"):
+            materialize_xls_bundle.resolve_archive_identity(
+                xls_version = "",
+                xls_git_revision = "8c5c112b4563401d33b4da1dcd4d7f69db54e0e5",
+                driver_version = "",
+                driver_git_revision = "0910ee19072a39a960b8df85b4f1e25199a4b4be",
+                list_remote_tags_fn = lambda _repo_url: {},
+                read_text_fn = lambda _url: 'const RELEASE_LIB_VERSION_TAG: &str = "v0.50.1";\n',
+            )
+
+    def test_resolve_archive_identity_requires_explicit_mismatch_override(self):
+        kwargs = {
+            "xls_version": "v0.50.1",
+            "xls_git_revision": "",
+            "driver_version": "",
+            "driver_git_revision": "0910ee19072a39a960b8df85b4f1e25199a4b4be",
+            "list_remote_tags_fn": lambda _repo_url: {
+                "v0.50.1": "8c5c112b4563401d33b4da1dcd4d7f69db54e0e5",
+            },
+            "read_text_fn": lambda _url: 'const RELEASE_LIB_VERSION_TAG: &str = "v0.49.0";\n',
+        }
+        with self.assertRaisesRegex(ValueError, "allow_xls_pin_mismatch"):
+            materialize_xls_bundle.resolve_archive_identity(**kwargs)
+
+        identity = materialize_xls_bundle.resolve_archive_identity(
+            allow_xls_pin_mismatch = True,
+            **kwargs
+        )
+        self.assertEqual(identity["crate_implied_xls_release_tag"], "v0.49.0")
+        self.assertEqual(identity["resolved_xls_release_tag"], "v0.50.1")
+
+    def test_write_resolved_identity_is_stable_json(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            materialize_xls_bundle.write_resolved_identity(
+                repo_root,
+                {
+                    "schema_version": 1,
+                    "xls_pin": {
+                        "kind": "release_tag",
+                        "value": "v0.50.1",
+                    },
+                },
+            )
+
+            self.assertEqual(
+                (repo_root / "resolved_identity.json").read_text(encoding = "utf-8"),
+                """{
+  "schema_version": 1,
+  "xls_pin": {
+    "kind": "release_tag",
+    "value": "v0.50.1"
+  }
+}
+""",
+            )
+
+    def test_materialize_runtime_surface_removes_stale_resolved_identity(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            (repo_root / "resolved_identity.json").write_text("stale\n", encoding = "utf-8")
+            with mock.patch.object(
+                materialize_xls_bundle,
+                "resolve_materialization_inputs",
+                return_value = {},
+            ):
+                with mock.patch.object(materialize_xls_bundle, "stage_runtime_payload"):
+                    materialize_xls_bundle.materialize_runtime_surface(repo_root, {})
+
+            self.assertFalse((repo_root / "resolved_identity.json").exists())
+
+    def test_materialize_runtime_surface_rejects_private_filename_collision(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            with mock.patch.object(
+                materialize_xls_bundle,
+                "resolve_materialization_inputs",
+                return_value = {
+                    "runtime_files": [repo_root / "inputs" / "resolved_identity.json"],
+                },
+            ):
+                with mock.patch.object(
+                    materialize_xls_bundle,
+                    "stage_runtime_payload",
+                ) as mock_stage:
+                    with self.assertRaisesRegex(ValueError, "reserved private filenames"):
+                        materialize_xls_bundle.materialize_runtime_surface(repo_root, {})
+            mock_stage.assert_not_called()
+
+    def test_trusted_resolved_identity_requires_download_only_artifacts(self):
+        materialize_xls_bundle.validate_resolved_identity_inputs(
+            "download_only",
+            "",
+        )
+        for artifact_source in ["auto", "installed_only", "local_paths"]:
+            with self.subTest(artifact_source = artifact_source):
+                with self.assertRaisesRegex(ValueError, "requires artifact_source=download_only"):
+                    materialize_xls_bundle.validate_resolved_identity_inputs(
+                        artifact_source,
+                        "",
+                    )
+
+    def test_trusted_resolved_identity_rejects_local_aot_runtime_source(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "cannot use local_xls_aot_runtime_source_path",
+        ):
+            materialize_xls_bundle.validate_resolved_identity_inputs(
+                "download_only",
+                "/tmp/review/xls-aot-runtime-source.tar.gz",
+            )
+
     def test_build_rustup_toolchain_install_command_uses_minimal_profile(self):
         command = materialize_xls_bundle.build_rustup_toolchain_install_command("/usr/bin/rustup")
         self.assertEqual(
@@ -446,6 +728,7 @@ printf 'fallback body\\n'
             host_platform = "arm64",
         )
         self.assertEqual(env["RUSTUP_HOME"], "/tmp/xls-bundle-repo/_rustup_home/arm64")
+        self.assertEqual(env["CARGO_HOME"], "/tmp/xls-bundle-repo/_cargo_home/arm64")
         self.assertEqual(env["CARGO_TARGET_DIR"], "/tmp/xls-bundle-repo/_cargo_target/arm64")
 
     def test_driver_install_root_is_version_and_platform_scoped(self):
@@ -572,6 +855,159 @@ printf 'fallback body\\n'
                 universal_newlines = True,
                 env = mock.ANY,
             )
+
+    def test_install_driver_uses_exact_git_revision(self):
+        revision = "0910ee19072a39a960b8df85b4f1e25199a4b4be"
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            install_root = repo_root / "_cargo_driver" / "arm64" / revision
+            with mock.patch.object(materialize_xls_bundle, "detect_host_platform", return_value = "arm64"):
+                with mock.patch.object(materialize_xls_bundle.shutil, "which", return_value = "/usr/bin/rustup"):
+                    with mock.patch.object(materialize_xls_bundle, "ensure_rustup_nightly_toolchain"):
+                        with mock.patch.object(materialize_xls_bundle, "validate_installed_driver"):
+                            with mock.patch.object(materialize_xls_bundle, "write_driver_git_provenance"):
+                                with mock.patch.object(materialize_xls_bundle.subprocess, "run") as mock_run:
+                                    materialize_xls_bundle.install_driver(
+                                        repo_root = repo_root,
+                                        driver_version = "",
+                                        driver_git_revision = revision,
+                                        libxls_path = "/tmp/xls-bundle/libxls.dylib" if sys.platform == "darwin" else "/tmp/xls-bundle/libxls.so",
+                                        dslx_stdlib_path = "/tmp/xls-bundle",
+                                    )
+
+            mock_run.assert_called_once_with(
+                [
+                    "/usr/bin/rustup",
+                    "run",
+                    "nightly",
+                    "cargo",
+                    "install",
+                    "--locked",
+                    "--root",
+                    str(install_root),
+                    "--git",
+                    "https://github.com/xlsynth/xlsynth-crate.git",
+                    "--rev",
+                    revision,
+                    "xlsynth-driver",
+                ],
+                check = True,
+                env = mock.ANY,
+            )
+
+    def test_git_driver_provenance_binds_revision_and_driver_bytes(self):
+        revision = "0910ee19072a39a960b8df85b4f1e25199a4b4be"
+        with tempfile.TemporaryDirectory() as tempdir:
+            driver_path = Path(tempdir) / "bin" / "xlsynth-driver"
+            driver_path.parent.mkdir()
+            driver_path.write_bytes(b"driver bytes")
+
+            materialize_xls_bundle.write_driver_git_provenance(driver_path, revision)
+            materialize_xls_bundle.validate_driver_git_provenance(driver_path, revision)
+
+            driver_path.write_bytes(b"different driver bytes")
+            with self.assertRaisesRegex(RuntimeError, "does not match"):
+                materialize_xls_bundle.validate_driver_git_provenance(driver_path, revision)
+
+    def test_git_driver_provenance_is_required_for_installed_revision(self):
+        revision = "0910ee19072a39a960b8df85b4f1e25199a4b4be"
+        with tempfile.TemporaryDirectory() as tempdir:
+            driver_path = Path(tempdir) / "bin" / "xlsynth-driver"
+            driver_path.parent.mkdir()
+            driver_path.write_bytes(b"driver bytes")
+
+            with self.assertRaisesRegex(RuntimeError, "requires valid provenance"):
+                materialize_xls_bundle.validate_driver_git_provenance(driver_path, revision)
+
+    def test_installed_git_driver_materialization_requires_provenance(self):
+        revision = "0910ee19072a39a960b8df85b4f1e25199a4b4be"
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            driver_path = root / "bin" / "xlsynth-driver"
+            driver_path.parent.mkdir()
+            driver_path.write_text("#!/bin/sh\nexit 0\n", encoding = "utf-8")
+            driver_path.chmod(0o755)
+
+            with self.assertRaisesRegex(RuntimeError, "requires valid provenance"):
+                materialize_xls_bundle.materialize_driver_binary(
+                    repo_root = root / "repo",
+                    plan = {
+                        "mode": "installed",
+                        "driver": driver_path,
+                        "driver_version": "",
+                        "driver_git_revision": revision,
+                    },
+                    driver_output = root / "out" / "xlsynth-driver",
+                    libxls_path = root / "runtime" / "libxls.so",
+                    dslx_stdlib_path = root / "stdlib",
+                )
+
+    def test_installed_git_driver_materialization_accepts_matching_provenance(self):
+        revision = "0910ee19072a39a960b8df85b4f1e25199a4b4be"
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            driver_path = root / "bin" / "xlsynth-driver"
+            driver_path.parent.mkdir()
+            driver_path.write_text("#!/bin/sh\nexit 0\n", encoding = "utf-8")
+            driver_path.chmod(0o755)
+            materialize_xls_bundle.write_driver_git_provenance(driver_path, revision)
+            output_path = root / "out" / "xlsynth-driver"
+
+            materialize_xls_bundle.materialize_driver_binary(
+                repo_root = root / "repo",
+                plan = {
+                    "mode": "installed",
+                    "driver": driver_path,
+                    "driver_version": "",
+                    "driver_git_revision": revision,
+                },
+                driver_output = output_path,
+                libxls_path = root / "runtime" / "libxls.so",
+                dslx_stdlib_path = root / "stdlib",
+            )
+
+            self.assertEqual(output_path.read_bytes(), driver_path.read_bytes())
+
+    def test_auto_git_driver_materialization_reinstalls_without_provenance(self):
+        revision = "0910ee19072a39a960b8df85b4f1e25199a4b4be"
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            declared_driver = root / "declared" / "xlsynth-driver"
+            declared_driver.parent.mkdir()
+            declared_driver.write_text("#!/bin/sh\nexit 0\n", encoding = "utf-8")
+            declared_driver.chmod(0o755)
+            fallback_driver = root / "fallback" / "xlsynth-driver"
+            fallback_driver.parent.mkdir()
+            fallback_driver.write_text("#!/bin/sh\nprintf 'fallback\\n'\n", encoding = "utf-8")
+            fallback_driver.chmod(0o755)
+
+            with mock.patch.object(
+                materialize_xls_bundle,
+                "install_driver",
+                return_value = fallback_driver,
+            ) as mock_install:
+                materialize_xls_bundle.materialize_driver_binary(
+                    repo_root = root / "repo",
+                    plan = {
+                        "mode": "auto_driver_input",
+                        "driver": declared_driver,
+                        "driver_version": "",
+                        "driver_git_revision": revision,
+                    },
+                    driver_output = root / "out" / "xlsynth-driver",
+                    libxls_path = root / "runtime" / "libxls.so",
+                    dslx_stdlib_path = root / "stdlib",
+                )
+
+            mock_install.assert_called_once_with(
+                root / "repo",
+                "",
+                root / "runtime" / "libxls.so",
+                root / "stdlib",
+                rustup_path = "",
+                driver_git_revision = revision,
+            )
+            self.assertIn("fallback", (root / "out" / "xlsynth-driver").read_text(encoding = "utf-8"))
 
     def test_parse_readelf_soname_finds_soname(self):
         self.assertEqual(
@@ -821,6 +1257,234 @@ Tag        Type                         Name/Value
 
             self.assertEqual(driver_output.read_text(encoding = "utf-8"), "#!/bin/sh\nexit 0\n")
             self.assertTrue(os.access(driver_output, os.X_OK))
+
+    def test_driver_resolved_identity_must_match_selected_driver_pin(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            identity_input = root / "runtime_identity.json"
+            identity_output = root / "driver_identity.json"
+            identity_input.write_text(
+                json.dumps({
+                    "schema_version": 1,
+                    "xlsynth_crate_pin": {
+                        "kind": "release_tag",
+                        "value": "v0.50.0",
+                    },
+                    "xls_pin": {
+                        "kind": "release_tag",
+                        "value": "v0.50.1",
+                    },
+                    "resolved_xlsynth_crate_revision": "a" * 40,
+                    "crate_implied_xls_release_tag": "v0.50.1",
+                    "resolved_xls_release_tag": "v0.50.1",
+                    "resolved_xls_revision": "b" * 40,
+                }),
+                encoding = "utf-8",
+            )
+            plan = {
+                "driver_version": "0.50.0",
+            }
+
+            materialize_xls_bundle.validate_and_copy_driver_resolved_identity(
+                identity_input,
+                identity_output,
+                plan,
+            )
+            self.assertEqual(identity_output.read_bytes(), identity_input.read_bytes())
+
+            plan["driver_version"] = "0.51.0"
+            with self.assertRaisesRegex(ValueError, "does not match selected driver pin"):
+                materialize_xls_bundle.validate_and_copy_driver_resolved_identity(
+                    identity_input,
+                    identity_output,
+                    plan,
+                )
+
+    def test_driver_resolved_identity_rejects_incomplete_manifest(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            identity_input = root / "runtime_identity.json"
+            identity_output = root / "driver_identity.json"
+            identity_input.write_text(
+                json.dumps({
+                    "xlsynth_crate_pin": {
+                        "kind": "release_tag",
+                        "value": "v0.50.0",
+                    },
+                }),
+                encoding = "utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "required schema fields"):
+                materialize_xls_bundle.validate_and_copy_driver_resolved_identity(
+                    identity_input,
+                    identity_output,
+                    {"driver_version": "0.50.0"},
+                )
+
+    def test_driver_resolved_identity_rejects_malformed_typed_values(self):
+        valid_identity = {
+            "schema_version": 1,
+            "xlsynth_crate_pin": {
+                "kind": "release_tag",
+                "value": "v0.50.0",
+            },
+            "xls_pin": {
+                "kind": "release_tag",
+                "value": "v0.50.1",
+            },
+            "resolved_xlsynth_crate_revision": "a" * 40,
+            "crate_implied_xls_release_tag": "v0.50.1",
+            "resolved_xls_release_tag": "v0.50.1",
+            "resolved_xls_revision": "b" * 40,
+        }
+        malformed_cases = [
+            (
+                "crate Git revision",
+                {
+                    **valid_identity,
+                    "xlsynth_crate_pin": {
+                        "kind": "git_revision",
+                        "value": "A" * 40,
+                    },
+                },
+                "lowercase exact SHA",
+            ),
+            (
+                "XLS release pin",
+                {
+                    **valid_identity,
+                    "xls_pin": {
+                        "kind": "release_tag",
+                        "value": "vnext",
+                    },
+                },
+                "not an XLS release tag",
+            ),
+            (
+                "resolved XLS release",
+                {
+                    **valid_identity,
+                    "resolved_xls_release_tag": "vnext",
+                },
+                "not an XLS release tag",
+            ),
+        ]
+        for label, identity, error in malformed_cases:
+            with self.subTest(label):
+                with tempfile.TemporaryDirectory() as tempdir:
+                    root = Path(tempdir)
+                    identity_input = root / "runtime_identity.json"
+                    identity_output = root / "driver_identity.json"
+                    identity_input.write_text(json.dumps(identity), encoding = "utf-8")
+
+                    with self.assertRaisesRegex(ValueError, error):
+                        materialize_xls_bundle.validate_and_copy_driver_resolved_identity(
+                            identity_input,
+                            identity_output,
+                            {"driver_version": "0.50.0"},
+                        )
+
+    def test_driver_resolved_identity_rejects_contradictory_typed_values(self):
+        crate_revision = "a" * 40
+        xls_revision = "b" * 40
+        valid_release_identity = {
+            "schema_version": 1,
+            "xlsynth_crate_pin": {
+                "kind": "release_tag",
+                "value": "v0.50.0",
+            },
+            "xls_pin": {
+                "kind": "release_tag",
+                "value": "v0.50.1",
+            },
+            "resolved_xlsynth_crate_revision": crate_revision,
+            "crate_implied_xls_release_tag": "v0.50.1",
+            "resolved_xls_release_tag": "v0.50.1",
+            "resolved_xls_revision": xls_revision,
+        }
+        cases = [
+            (
+                {
+                    **valid_release_identity,
+                    "xls_pin": {
+                        "kind": "git_revision",
+                        "value": "c" * 40,
+                    },
+                },
+                {"driver_version": "0.50.0"},
+                "XLS Git pin",
+            ),
+            (
+                {
+                    **valid_release_identity,
+                    "resolved_xls_release_tag": "v0.49.0",
+                },
+                {"driver_version": "0.50.0"},
+                "XLS release pin",
+            ),
+            (
+                {
+                    **valid_release_identity,
+                    "xlsynth_crate_pin": {
+                        "kind": "git_revision",
+                        "value": "c" * 40,
+                    },
+                },
+                {"driver_git_revision": "c" * 40},
+                "xlsynth-crate Git pin",
+            ),
+        ]
+        for identity, plan, expected_error in cases:
+            with self.subTest(expected_error):
+                with tempfile.TemporaryDirectory() as tempdir:
+                    root = Path(tempdir)
+                    identity_input = root / "runtime_identity.json"
+                    identity_output = root / "driver_identity.json"
+                    identity_input.write_text(json.dumps(identity), encoding = "utf-8")
+
+                    with self.assertRaisesRegex(ValueError, expected_error):
+                        materialize_xls_bundle.validate_and_copy_driver_resolved_identity(
+                            identity_input,
+                            identity_output,
+                            plan,
+                        )
+
+    def test_driver_resolved_identity_requires_explicit_xls_mismatch_override(self):
+        identity = {
+            "schema_version": 1,
+            "xlsynth_crate_pin": {
+                "kind": "release_tag",
+                "value": "v0.36.0",
+            },
+            "xls_pin": {
+                "kind": "release_tag",
+                "value": "v0.40.0",
+            },
+            "resolved_xlsynth_crate_revision": "a" * 40,
+            "crate_implied_xls_release_tag": "v0.39.0",
+            "resolved_xls_release_tag": "v0.40.0",
+            "resolved_xls_revision": "b" * 40,
+        }
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            identity_input = root / "runtime_identity.json"
+            identity_output = root / "driver_identity.json"
+            identity_input.write_text(json.dumps(identity), encoding = "utf-8")
+
+            with self.assertRaisesRegex(ValueError, "explicit development override"):
+                materialize_xls_bundle.validate_and_copy_driver_resolved_identity(
+                    identity_input,
+                    identity_output,
+                    {"driver_version": "0.36.0"},
+                )
+            materialize_xls_bundle.validate_and_copy_driver_resolved_identity(
+                identity_input,
+                identity_output,
+                {"driver_version": "0.36.0"},
+                allow_xls_pin_mismatch = True,
+            )
+            self.assertEqual(identity_output.read_bytes(), identity_input.read_bytes())
 
 
 if __name__ == "__main__":

--- a/artifact_resolution_test.py
+++ b/artifact_resolution_test.py
@@ -716,6 +716,7 @@ printf 'fallback body\\n'
                 "nightly",
                 "--profile",
                 "minimal",
+                "--no-self-update",
             ],
         )
 

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -10,6 +10,7 @@ _TOOL_BINARIES = [
     "delay_info_main",
     "check_ir_equivalence_main",
 ]
+_DRIVER_GIT_PROVENANCE_FILENAME = "xlsynth-driver.provenance.json"
 
 def _metadata_dict(repo_ctx, metadata_filename):
     metadata = {}
@@ -68,12 +69,12 @@ def _version_at_least(version, minimum):
 
 def _driver_supports_sv_enum_case_naming_policy(driver_version):
     if not driver_version:
-        return True
+        return False
     return _version_at_least(driver_version, "0.33.0")
 
 def _driver_supports_sv_struct_field_ordering(driver_version):
     if not driver_version:
-        return True
+        return False
     return _version_at_least(driver_version, "0.36.0")
 
 def _runtime_build_file(
@@ -82,7 +83,9 @@ def _runtime_build_file(
         xls_aot_runtime_link_config_name,
         xls_aot_runtime_source_repo,
         runtime_files,
-        runtime_aliases):
+        runtime_aliases,
+        resolved_identity,
+        toolchain_repo_name):
     tool_list = ",\n        ".join(['"{}"'.format(name) for name in _TOOL_BINARIES])
     exported_names = _TOOL_BINARIES + [libxls_name] + runtime_files + runtime_aliases
     if xls_aot_runtime_name:
@@ -121,6 +124,15 @@ alias(
 """.format(
         xls_aot_runtime_source_repo = xls_aot_runtime_source_repo,
     ) if xls_aot_runtime_source_repo else ""
+    resolved_identity_rule = """
+filegroup(
+    name = "resolved_identity_for_toolchain",
+    srcs = ["resolved_identity.json"],
+    visibility = ["@{toolchain_repo_name}//:__pkg__"],
+)
+""".format(
+        toolchain_repo_name = toolchain_repo_name,
+    ) if resolved_identity else ""
     lib_file_rule = """
 filegroup(
     name = "libxls_file",
@@ -174,6 +186,7 @@ copy_flat_files_to_directory(
 {lib_file_rule}
 {aot_runtime_rule}
 {aot_runtime_source_rule}
+{resolved_identity_rule}
 
 xlsynth_artifact_config(
     name = "artifact_config",
@@ -241,6 +254,7 @@ xls_runtime_surface(
         lib_file_rule = lib_file_rule.strip(),
         aot_runtime_rule = aot_runtime_rule.strip(),
         aot_runtime_source_rule = aot_runtime_source_rule.strip(),
+        resolved_identity_rule = resolved_identity_rule.strip(),
         static_aot_runtime = '":xls_aot_runtime_file"' if xls_aot_runtime_name else "None",
         static_aot_runtime_link_config = '":xls_aot_runtime_link_config_file"' if xls_aot_runtime_name else "None",
     )
@@ -260,10 +274,14 @@ def _toolchain_build_file(
         action_ld_library_path,
         action_rustup_home,
         artifact_source,
+        allow_xls_pin_mismatch,
+        emit_resolved_identity,
         host_driver_label,
+        host_driver_provenance_label,
         installed_driver_root_prefix,
         local_driver_path,
         rustup_path,
+        xlsynth_driver_git_revision,
         xlsynth_driver_version):
     action_env_attrs = "".join([
         _string_attr_line("action_cargo_home", action_cargo_home),
@@ -273,10 +291,15 @@ def _toolchain_build_file(
         _string_attr_line("action_rustup_home", action_rustup_home),
     ])
     driver_attrs = "".join([
+        (
+            "    resolved_identity = \"@{}//:resolved_identity_for_toolchain\",\n".format(runtime_repo_name) if emit_resolved_identity else ""
+        ),
         _string_attr_line("host_driver", host_driver_label),
+        _string_attr_line("host_driver_provenance", host_driver_provenance_label),
         _string_attr_line("installed_driver_root_prefix", installed_driver_root_prefix),
         _string_attr_line("local_driver_path", local_driver_path),
         _string_attr_line("rustup_path", rustup_path),
+        _string_attr_line("xlsynth_driver_git_revision", xlsynth_driver_git_revision),
         _string_attr_line("xlsynth_driver_version", xlsynth_driver_version),
     ])
     return """# SPDX-License-Identifier: Apache-2.0
@@ -286,7 +309,8 @@ load("@rules_xlsynth//:xls_toolchain.bzl", "xls_bundle", "xls_toolchain", "xlsyn
 xlsynth_driver_binary(
     name = "xlsynth-driver",
     action_path = {action_path},
-{action_env_attrs}    artifact_source = {artifact_source},
+{action_env_attrs}    allow_xls_pin_mismatch = {allow_xls_pin_mismatch},
+    artifact_source = {artifact_source},
     runtime = "@{runtime_repo_name}//:runtime",
 {driver_attrs})
 
@@ -320,9 +344,10 @@ toolchain(
         artifact_source = _quoted(artifact_source),
         action_env_attrs = action_env_attrs,
         action_path = _quoted(action_path),
+        allow_xls_pin_mismatch = "True" if allow_xls_pin_mismatch else "False",
         driver_attrs = driver_attrs,
-        driver_supports_sv_enum_case_naming_policy = "True" if _driver_supports_sv_enum_case_naming_policy(xlsynth_driver_version) else "False",
-        driver_supports_sv_struct_field_ordering = "True" if _driver_supports_sv_struct_field_ordering(xlsynth_driver_version) else "False",
+        driver_supports_sv_enum_case_naming_policy = "True" if not xlsynth_driver_git_revision and _driver_supports_sv_enum_case_naming_policy(xlsynth_driver_version) else "False",
+        driver_supports_sv_struct_field_ordering = "True" if not xlsynth_driver_git_revision and _driver_supports_sv_struct_field_ordering(xlsynth_driver_version) else "False",
         repo_alias = repo_alias,
         runtime_repo_name = runtime_repo_name,
     )
@@ -339,33 +364,56 @@ def _driver_path_to_stage(repo_ctx):
 
 def _driver_repo_impl(repo_ctx):
     link_name = "host_xlsynth-driver"
+    provenance_name = _DRIVER_GIT_PROVENANCE_FILENAME
     driver_path = _driver_path_to_stage(repo_ctx)
     if driver_path == None:
         repo_ctx.file(link_name, "#!/bin/sh\nexit 127\n", executable = True)
     else:
         repo_ctx.symlink(driver_path, link_name)
+    provenance_path = repo_ctx.path(repo_ctx.attr.driver_provenance_path)
+    if repo_ctx.attr.driver_provenance_path and provenance_path.exists:
+        repo_ctx.symlink(provenance_path, provenance_name)
+    else:
+        repo_ctx.file(provenance_name, "{}\n")
     repo_ctx.file(
         "BUILD.bazel",
         """# SPDX-License-Identifier: Apache-2.0
 
-exports_files(["host_xlsynth-driver"])
+exports_files([
+    "host_xlsynth-driver",
+    "xlsynth-driver.provenance.json",
+])
 """,
     )
 
 def _host_driver_path(toolchain):
     if toolchain.artifact_source == "local_paths":
         return toolchain.local_driver_path
-    if toolchain.artifact_source in ("auto", "installed_only") and toolchain.installed_driver_root_prefix and toolchain.xlsynth_driver_version:
-        return _installed_driver_path(toolchain.xlsynth_driver_version, toolchain.installed_driver_root_prefix)
+    if toolchain.artifact_source in ("auto", "installed_only") and toolchain.installed_driver_root_prefix:
+        if toolchain.xlsynth_driver_git_revision:
+            return _installed_driver_path(toolchain.xlsynth_driver_git_revision, toolchain.installed_driver_root_prefix)
+        if toolchain.xlsynth_driver_version:
+            return _installed_driver_path(toolchain.xlsynth_driver_version, toolchain.installed_driver_root_prefix)
     return ""
 
 def _host_driver_required(toolchain):
     return toolchain.artifact_source in ("local_paths", "installed_only")
 
+def _host_driver_provenance_path(toolchain):
+    driver_path = _host_driver_path(toolchain)
+    if not driver_path or not toolchain.xlsynth_driver_git_revision:
+        return ""
+    return driver_path.rsplit("/", 1)[0] + "/" + _DRIVER_GIT_PROVENANCE_FILENAME
+
 def _host_driver_label(toolchain, driver_name):
     if not _host_driver_path(toolchain):
         return ""
     return "@{}//:host_xlsynth-driver".format(driver_name)
+
+def _host_driver_provenance_label(toolchain, driver_name):
+    if not _host_driver_provenance_path(toolchain):
+        return ""
+    return "@{}//:{}".format(driver_name, _DRIVER_GIT_PROVENANCE_FILENAME)
 
 def _materialize_bundle_args(repo_ctx, surface):
     args = [
@@ -379,8 +427,16 @@ def _materialize_bundle_args(repo_ctx, surface):
     ]
     if repo_ctx.attr.xls_version:
         args.extend(["--xls-version", repo_ctx.attr.xls_version])
+    if repo_ctx.attr.xls_git_revision:
+        args.extend(["--xls-git-revision", repo_ctx.attr.xls_git_revision])
     if repo_ctx.attr.xlsynth_driver_version:
         args.extend(["--xlsynth-driver-version", repo_ctx.attr.xlsynth_driver_version])
+    if repo_ctx.attr.xlsynth_driver_git_revision:
+        args.extend(["--xlsynth-driver-git-revision", repo_ctx.attr.xlsynth_driver_git_revision])
+    if repo_ctx.attr.emit_resolved_identity:
+        args.append("--emit-resolved-identity")
+    if repo_ctx.attr.allow_xls_pin_mismatch:
+        args.append("--allow-xls-pin-mismatch")
     if repo_ctx.attr.installed_tools_root_prefix:
         args.extend(["--installed-tools-root-prefix", repo_ctx.attr.installed_tools_root_prefix])
     if repo_ctx.attr.installed_driver_root_prefix:
@@ -438,6 +494,8 @@ def _runtime_repo_impl(repo_ctx):
             xls_aot_runtime_source_repo = metadata["xls_aot_runtime_source_repo"],
             runtime_files = runtime_files,
             runtime_aliases = runtime_aliases,
+            resolved_identity = repo_ctx.path("resolved_identity.json").exists,
+            toolchain_repo_name = repo_ctx.attr.toolchain_repo_name,
         ),
     )
 
@@ -460,17 +518,23 @@ def _toolchain_repo_impl(repo_ctx):
             action_home = action_home,
             action_ld_library_path = action_ld_library_path,
             action_rustup_home = action_rustup_home,
+            allow_xls_pin_mismatch = repo_ctx.attr.allow_xls_pin_mismatch,
             artifact_source = repo_ctx.attr.artifact_source,
+            emit_resolved_identity = repo_ctx.attr.emit_resolved_identity,
             host_driver_label = repo_ctx.attr.host_driver_label,
+            host_driver_provenance_label = repo_ctx.attr.host_driver_provenance_label,
             installed_driver_root_prefix = repo_ctx.attr.installed_driver_root_prefix,
             local_driver_path = repo_ctx.attr.local_driver_path,
             rustup_path = "" if rustup == None else str(rustup),
+            xlsynth_driver_git_revision = repo_ctx.attr.xlsynth_driver_git_revision,
             xlsynth_driver_version = repo_ctx.attr.xlsynth_driver_version,
         ),
     )
 
 _runtime_repo_attrs = {
+    "allow_xls_pin_mismatch": attr.bool(),
     "artifact_source": attr.string(mandatory = True),
+    "emit_resolved_identity": attr.bool(),
     "installed_driver_root_prefix": attr.string(),
     "installed_tools_root_prefix": attr.string(),
     "local_driver_path": attr.string(),
@@ -480,13 +544,19 @@ _runtime_repo_attrs = {
     "local_xls_aot_runtime_link_config_path": attr.string(),
     "local_xls_aot_runtime_source_path": attr.string(),
     "local_tools_path": attr.string(),
+    "toolchain_repo_name": attr.string(mandatory = True),
     "xls_version": attr.string(),
+    "xls_git_revision": attr.string(),
+    "xlsynth_driver_git_revision": attr.string(),
     "xlsynth_driver_version": attr.string(),
 }
 
 _toolchain_repo_attrs = {
+    "allow_xls_pin_mismatch": attr.bool(),
     "artifact_source": attr.string(mandatory = True),
+    "emit_resolved_identity": attr.bool(),
     "host_driver_label": attr.string(),
+    "host_driver_provenance_label": attr.string(),
     "installed_driver_root_prefix": attr.string(),
     "installed_tools_root_prefix": attr.string(),
     "local_driver_path": attr.string(),
@@ -499,11 +569,14 @@ _toolchain_repo_attrs = {
     "repo_alias": attr.string(mandatory = True),
     "runtime_repo_name": attr.string(mandatory = True),
     "xls_version": attr.string(),
+    "xls_git_revision": attr.string(),
+    "xlsynth_driver_git_revision": attr.string(),
     "xlsynth_driver_version": attr.string(),
 }
 
 _driver_repo_attrs = {
     "driver_path": attr.string(),
+    "driver_provenance_path": attr.string(),
     "required": attr.bool(),
 }
 
@@ -531,7 +604,9 @@ _xls_driver_repo = repository_rule(
 )
 
 _toolchain_tag = tag_class(attrs = {
+    "allow_xls_pin_mismatch": attr.bool(),
     "artifact_source": attr.string(mandatory = True),
+    "emit_resolved_identity": attr.bool(),
     "installed_driver_root_prefix": attr.string(),
     "installed_tools_root_prefix": attr.string(),
     "local_driver_path": attr.string(),
@@ -543,6 +618,8 @@ _toolchain_tag = tag_class(attrs = {
     "local_tools_path": attr.string(),
     "name": attr.string(mandatory = True),
     "xls_version": attr.string(),
+    "xls_git_revision": attr.string(),
+    "xlsynth_driver_git_revision": attr.string(),
     "xlsynth_driver_version": attr.string(),
 })
 
@@ -554,7 +631,9 @@ def _xls_extension_impl(module_ctx):
             driver_name = _driver_repo_name(toolchain.name)
             _xls_runtime_repo(
                 name = runtime_name,
+                allow_xls_pin_mismatch = toolchain.allow_xls_pin_mismatch,
                 artifact_source = toolchain.artifact_source,
+                emit_resolved_identity = toolchain.emit_resolved_identity,
                 installed_driver_root_prefix = toolchain.installed_driver_root_prefix,
                 installed_tools_root_prefix = toolchain.installed_tools_root_prefix,
                 local_driver_path = toolchain.local_driver_path,
@@ -564,18 +643,25 @@ def _xls_extension_impl(module_ctx):
                 local_xls_aot_runtime_link_config_path = toolchain.local_xls_aot_runtime_link_config_path,
                 local_xls_aot_runtime_source_path = toolchain.local_xls_aot_runtime_source_path,
                 local_tools_path = toolchain.local_tools_path,
+                toolchain_repo_name = toolchain_name,
                 xls_version = toolchain.xls_version,
+                xls_git_revision = toolchain.xls_git_revision,
+                xlsynth_driver_git_revision = toolchain.xlsynth_driver_git_revision,
                 xlsynth_driver_version = toolchain.xlsynth_driver_version,
             )
             _xls_driver_repo(
                 name = driver_name,
                 driver_path = _host_driver_path(toolchain),
+                driver_provenance_path = _host_driver_provenance_path(toolchain),
                 required = _host_driver_required(toolchain),
             )
             _xls_toolchain_repo(
                 name = toolchain_name,
+                allow_xls_pin_mismatch = toolchain.allow_xls_pin_mismatch,
                 artifact_source = toolchain.artifact_source,
+                emit_resolved_identity = toolchain.emit_resolved_identity,
                 host_driver_label = _host_driver_label(toolchain, driver_name),
+                host_driver_provenance_label = _host_driver_provenance_label(toolchain, driver_name),
                 installed_driver_root_prefix = toolchain.installed_driver_root_prefix,
                 installed_tools_root_prefix = toolchain.installed_tools_root_prefix,
                 local_driver_path = toolchain.local_driver_path,
@@ -588,6 +674,8 @@ def _xls_extension_impl(module_ctx):
                 repo_alias = toolchain_name,
                 runtime_repo_name = runtime_name,
                 xls_version = toolchain.xls_version,
+                xls_git_revision = toolchain.xls_git_revision,
+                xlsynth_driver_git_revision = toolchain.xlsynth_driver_git_revision,
                 xlsynth_driver_version = toolchain.xlsynth_driver_version,
             )
 

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -77,6 +77,32 @@ def _driver_supports_sv_struct_field_ordering(driver_version):
         return False
     return _version_at_least(driver_version, "0.36.0")
 
+def _toolchain_driver_supports_sv_enum_case_naming_policy(
+        artifact_source,
+        local_driver_path,
+        xlsynth_driver_git_revision,
+        xlsynth_driver_version):
+    if artifact_source == "local_paths" and local_driver_path:
+        supports = True
+    elif xlsynth_driver_git_revision:
+        supports = False
+    else:
+        supports = _driver_supports_sv_enum_case_naming_policy(xlsynth_driver_version)
+    return supports
+
+def _toolchain_driver_supports_sv_struct_field_ordering(
+        artifact_source,
+        local_driver_path,
+        xlsynth_driver_git_revision,
+        xlsynth_driver_version):
+    if artifact_source == "local_paths" and local_driver_path:
+        supports = True
+    elif xlsynth_driver_git_revision:
+        supports = False
+    else:
+        supports = _driver_supports_sv_struct_field_ordering(xlsynth_driver_version)
+    return supports
+
 def _runtime_build_file(
         libxls_name,
         xls_aot_runtime_name,
@@ -346,8 +372,8 @@ toolchain(
         action_path = _quoted(action_path),
         allow_xls_pin_mismatch = "True" if allow_xls_pin_mismatch else "False",
         driver_attrs = driver_attrs,
-        driver_supports_sv_enum_case_naming_policy = "True" if not xlsynth_driver_git_revision and _driver_supports_sv_enum_case_naming_policy(xlsynth_driver_version) else "False",
-        driver_supports_sv_struct_field_ordering = "True" if not xlsynth_driver_git_revision and _driver_supports_sv_struct_field_ordering(xlsynth_driver_version) else "False",
+        driver_supports_sv_enum_case_naming_policy = "True" if _toolchain_driver_supports_sv_enum_case_naming_policy(artifact_source, local_driver_path, xlsynth_driver_git_revision, xlsynth_driver_version) else "False",
+        driver_supports_sv_struct_field_ordering = "True" if _toolchain_driver_supports_sv_struct_field_ordering(artifact_source, local_driver_path, xlsynth_driver_git_revision, xlsynth_driver_version) else "False",
         repo_alias = repo_alias,
         runtime_repo_name = runtime_repo_name,
     )

--- a/external_bundle_exports_test.py
+++ b/external_bundle_exports_test.py
@@ -1,3 +1,4 @@
+import json
 import os
 from pathlib import Path
 import unittest
@@ -111,6 +112,30 @@ class ExternalBundleExportsTest(unittest.TestCase):
         basenames = [Path(path).name for path in locations_file.read_text(encoding = "utf-8").split()]
         self.assertIn("dslx_stdlib", basenames)
         self.assertTrue(any(name.startswith("libxls") for name in basenames))
+
+    def test_resolved_identity_is_exported_as_declared_bundle_input(self):
+        runfiles_lookup = runfiles.Create()
+        workspace = os.environ["TEST_WORKSPACE"]
+
+        location_file = Path(
+            runfiles_lookup.Rlocation("{}/resolved_identity_location.txt".format(workspace)),
+        )
+        self.assertTrue(location_file.is_file())
+        self.assertEqual(
+            Path(location_file.read_text(encoding = "utf-8").strip()).name,
+            "xlsynth-driver.resolved_identity.json",
+        )
+
+        identity_path = Path(
+            runfiles_lookup.Rlocation(
+                "rules_xlsynth_selftest_xls_toolchain/xlsynth-driver.resolved_identity.json",
+            ),
+        )
+        identity = json.loads(identity_path.read_text(encoding = "utf-8"))
+        self.assertEqual(identity["xlsynth_crate_pin"], {"kind": "release_tag", "value": "v0.36.0"})
+        self.assertEqual(identity["xls_pin"], {"kind": "release_tag", "value": "v0.40.0"})
+        self.assertEqual(identity["crate_implied_xls_release_tag"], "v0.39.0")
+        self.assertEqual(identity["resolved_xls_release_tag"], "v0.40.0")
 
 
 if __name__ == "__main__":

--- a/materialize_xls_bundle.py
+++ b/materialize_xls_bundle.py
@@ -3,12 +3,15 @@
 """Materializes an XLS bundle repository for the rules_xlsynth module extension."""
 
 import argparse
+import hashlib
 import json
 import os
 from pathlib import Path
+import re
 import shutil
 import subprocess
 import sys
+from urllib import request as urlrequest
 
 TOOL_BINARIES = [
     "dslx_interpreter_main",
@@ -27,6 +30,20 @@ _DRIVER_CAPABILITY_FLAGS = {
     "driver_supports_sv_enum_case_naming_policy": "--sv_enum_case_naming_policy",
     "driver_supports_sv_struct_field_ordering": "--sv_struct_field_ordering",
 }
+
+_XLSYNTH_REPO_URL = "https://github.com/xlsynth/xlsynth.git"
+_XLSYNTH_CRATE_REPO_URL = "https://github.com/xlsynth/xlsynth-crate.git"
+_XLSYNTH_CRATE_BUILD_RS_URL = (
+    "https://raw.githubusercontent.com/xlsynth/xlsynth-crate/{}/xlsynth-sys/build.rs"
+)
+_GIT_REVISION_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+_RELEASE_TAG_RE = re.compile(r"^v[0-9A-Za-z][0-9A-Za-z.+-]*$")
+_XLS_RELEASE_TAG_RE = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9]+)?$")
+_CRATE_IMPLIED_XLS_RELEASE_RE = re.compile(
+    r'RELEASE_LIB_VERSION_TAG\s*:\s*&str\s*=\s*"([^"]+)"'
+)
+_DRIVER_GIT_PROVENANCE_FILENAME = "xlsynth-driver.provenance.json"
+_PRIVATE_RUNTIME_FILENAMES = {"resolved_identity.json"}
 
 
 def run_captured_text_command(args, check, env = None):
@@ -50,6 +67,208 @@ def normalize_version(version):
 
 def version_tag(version):
     return "v{}".format(normalize_version(version))
+
+
+def normalize_git_revision(revision):
+    if not _GIT_REVISION_RE.fullmatch(revision):
+        raise ValueError("Expected exact 40-character Git revision, got: {}".format(revision))
+    return revision.lower()
+
+
+def normalize_release_tag(version):
+    tag = version_tag(version)
+    if not _RELEASE_TAG_RE.fullmatch(tag):
+        raise ValueError("Expected release tag, got: {}".format(version))
+    return tag
+
+
+def producer_pin(version, git_revision, label):
+    if version and git_revision:
+        raise ValueError("{} accepts either a release tag or a Git revision, not both".format(label))
+    if version:
+        return {
+            "kind": "release_tag",
+            "value": normalize_release_tag(version),
+        }
+    if git_revision:
+        return {
+            "kind": "git_revision",
+            "value": normalize_git_revision(git_revision),
+        }
+    raise ValueError("{} requires either a release tag or a Git revision".format(label))
+
+
+def list_remote_tag_revisions(repo_url):
+    result = run_captured_text_command(
+        ["git", "ls-remote", "--tags", repo_url],
+        check = False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "Failed to list tags from {}\nstdout:\n{}\nstderr:\n{}".format(
+                repo_url,
+                result.stdout,
+                result.stderr,
+            )
+        )
+    direct_revisions = {}
+    peeled_revisions = {}
+    for line in result.stdout.splitlines():
+        if not line:
+            continue
+        revision, ref = line.split("\t", 1)
+        if not ref.startswith("refs/tags/"):
+            continue
+        tag = ref[len("refs/tags/"):]
+        if tag.endswith("^{}"):
+            peeled_revisions[tag[:-3]] = revision.lower()
+        else:
+            direct_revisions[tag] = revision.lower()
+    direct_revisions.update(peeled_revisions)
+    return direct_revisions
+
+
+def read_url_text(url):
+    with urlrequest.urlopen(url) as response:
+        return response.read().decode("utf-8")
+
+
+def resolve_release_tag_revision(repo_url, release_tag, list_remote_tags_fn = list_remote_tag_revisions):
+    revisions = list_remote_tags_fn(repo_url)
+    revision = revisions.get(release_tag)
+    if revision is None:
+        raise ValueError("{} does not publish release tag {}".format(repo_url, release_tag))
+    return normalize_git_revision(revision)
+
+
+def resolve_xls_pin(pin, list_remote_tags_fn = list_remote_tag_revisions):
+    if pin["kind"] == "release_tag":
+        release_tag = pin["value"]
+        if not _XLS_RELEASE_TAG_RE.fullmatch(release_tag):
+            raise ValueError("Expected XLS semantic release tag, got: {}".format(release_tag))
+        return {
+            "release_tag": release_tag,
+            "revision": resolve_release_tag_revision(
+                _XLSYNTH_REPO_URL,
+                release_tag,
+                list_remote_tags_fn = list_remote_tags_fn,
+            ),
+        }
+
+    revision = normalize_git_revision(pin["value"])
+    matching_tags = sorted(
+        tag
+        for tag, tag_revision in list_remote_tags_fn(_XLSYNTH_REPO_URL).items()
+        if tag_revision == revision and _XLS_RELEASE_TAG_RE.fullmatch(tag)
+    )
+    if not matching_tags:
+        raise ValueError(
+            "XLS Git revision {} does not map to a published XLS release tag".format(revision)
+        )
+    if len(matching_tags) != 1:
+        raise ValueError(
+            "XLS Git revision {} maps to multiple published XLS release tags: {}".format(
+                revision,
+                ", ".join(matching_tags),
+            )
+        )
+    return {
+        "release_tag": matching_tags[0],
+        "revision": revision,
+    }
+
+
+def crate_implied_xls_release_tag(crate_pin, read_text_fn = read_url_text):
+    try:
+        build_rs = read_text_fn(_XLSYNTH_CRATE_BUILD_RS_URL.format(crate_pin["value"]))
+    except Exception as error:
+        raise ValueError(
+            "xlsynth-crate Git revision {} could not be resolved".format(crate_pin["value"])
+        ) from error
+    match = _CRATE_IMPLIED_XLS_RELEASE_RE.search(build_rs)
+    if match is None:
+        raise ValueError(
+            "xlsynth-crate {} does not declare RELEASE_LIB_VERSION_TAG".format(
+                crate_pin["value"],
+            )
+        )
+    release_tag = match.group(1)
+    if not _XLS_RELEASE_TAG_RE.fullmatch(release_tag):
+        raise ValueError(
+            "xlsynth-crate {} declares invalid XLS release tag {}".format(
+                crate_pin["value"],
+                release_tag,
+            )
+        )
+    return release_tag
+
+
+def resolve_archive_identity(
+        xls_version,
+        xls_git_revision,
+        driver_version,
+        driver_git_revision,
+        allow_xls_pin_mismatch = False,
+        list_remote_tags_fn = list_remote_tag_revisions,
+        read_text_fn = read_url_text):
+    xlsynth_crate_pin = producer_pin(driver_version, driver_git_revision, "xlsynth-crate pin")
+    xls_pin = producer_pin(xls_version, xls_git_revision, "XLS pin")
+    resolved_xls = resolve_xls_pin(xls_pin, list_remote_tags_fn = list_remote_tags_fn)
+    if xlsynth_crate_pin["kind"] == "release_tag":
+        resolved_crate_revision = resolve_release_tag_revision(
+            _XLSYNTH_CRATE_REPO_URL,
+            xlsynth_crate_pin["value"],
+            list_remote_tags_fn = list_remote_tags_fn,
+        )
+    else:
+        resolved_crate_revision = xlsynth_crate_pin["value"]
+    implied_xls_release_tag = crate_implied_xls_release_tag(
+        {
+            "value": resolved_crate_revision,
+        },
+        read_text_fn = read_text_fn,
+    )
+    if implied_xls_release_tag != resolved_xls["release_tag"] and not allow_xls_pin_mismatch:
+        raise ValueError(
+            "xlsynth-crate {} implies XLS release {}, but explicit XLS pin resolves to {}; "
+            "set allow_xls_pin_mismatch only for deliberate development overrides".format(
+                xlsynth_crate_pin["value"],
+                implied_xls_release_tag,
+                resolved_xls["release_tag"],
+            )
+        )
+    return {
+        "schema_version": 1,
+        "xlsynth_crate_pin": xlsynth_crate_pin,
+        "xls_pin": xls_pin,
+        "resolved_xlsynth_crate_revision": resolved_crate_revision,
+        "crate_implied_xls_release_tag": implied_xls_release_tag,
+        "resolved_xls_release_tag": resolved_xls["release_tag"],
+        "resolved_xls_revision": resolved_xls["revision"],
+    }
+
+
+def write_resolved_identity(repo_root, identity):
+    (repo_root / "resolved_identity.json").write_text(
+        json.dumps(identity, indent = 2, sort_keys = True) + "\n",
+        encoding = "utf-8",
+    )
+
+
+def validate_resolved_identity_inputs(
+    artifact_source,
+    local_xls_aot_runtime_source_path,
+):
+    if artifact_source != "download_only":
+        raise ValueError(
+            "trusted resolved identity requires artifact_source=download_only; "
+            "{} may reuse consumer-owned artifacts".format(artifact_source)
+        )
+    elif local_xls_aot_runtime_source_path:
+        raise ValueError(
+            "trusted resolved identity cannot use local_xls_aot_runtime_source_path; "
+            "the local source is not covered by the resolved XLS identity"
+        )
 
 
 def libxls_name_for_platform(sys_platform):
@@ -123,6 +342,7 @@ def resolve_artifact_plan(
     artifact_source,
     xls_version,
     driver_version,
+    driver_git_revision = "",
     surface = "toolchain",
     installed_tools_root_prefix = "",
     installed_driver_root_prefix = "",
@@ -138,10 +358,13 @@ def resolve_artifact_plan(
     if surface not in ("runtime", "toolchain"):
         raise ValueError("Unknown XLS bundle surface: {}".format(surface))
     include_driver = surface == "toolchain"
+    if driver_version and driver_git_revision:
+        raise ValueError("XLS bundle accepts either an xlsynth driver release tag or Git revision, not both")
+    driver_identity = normalize_git_revision(driver_git_revision) if driver_git_revision else normalize_version(driver_version)
 
     if artifact_source == "local_paths":
-        if xls_version or driver_version:
-            raise ValueError("local_paths does not accept xls_version or xlsynth_driver_version")
+        if xls_version or driver_identity:
+            raise ValueError("local_paths does not accept XLS or xlsynth driver release or Git pins")
         required = {
             "local_tools_path": local_tools_path,
             "local_dslx_stdlib_path": local_dslx_stdlib_path,
@@ -182,8 +405,8 @@ def resolve_artifact_plan(
         raise ValueError("Unknown artifact_source: {}".format(artifact_source))
     if not xls_version:
         raise ValueError("{} requires xls_version".format(artifact_source))
-    if include_driver and not driver_version:
-        raise ValueError("{} toolchain surface requires xlsynth_driver_version".format(artifact_source))
+    if include_driver and not driver_identity:
+        raise ValueError("{} toolchain surface requires an xlsynth driver release or Git pin".format(artifact_source))
     if (
         local_tools_path
         or local_dslx_stdlib_path
@@ -207,7 +430,7 @@ def resolve_artifact_plan(
     if include_driver:
         installed_paths = derive_installed_paths(
             xls_version = xls_version,
-            driver_version = driver_version,
+            driver_version = driver_identity,
             installed_tools_root_prefix = installed_tools_root_prefix,
             installed_driver_root_prefix = installed_driver_root_prefix,
         )
@@ -226,6 +449,8 @@ def resolve_artifact_plan(
             plan["xls_aot_runtime_source"] = Path(local_xls_aot_runtime_source_path)
         if include_driver:
             plan["driver_version"] = normalize_version(driver_version)
+            if driver_git_revision:
+                plan["driver_git_revision"] = normalize_git_revision(driver_git_revision)
         return plan
 
     installed_paths_present = all(
@@ -273,6 +498,9 @@ def resolve_artifact_plan(
         }
         if include_driver:
             plan["driver"] = installed_paths["driver"]
+            plan["driver_version"] = normalize_version(driver_version)
+            if driver_git_revision:
+                plan["driver_git_revision"] = normalize_git_revision(driver_git_revision)
         if local_xls_aot_runtime_source_path:
             plan["xls_aot_runtime_source"] = Path(local_xls_aot_runtime_source_path)
         return plan
@@ -282,7 +510,7 @@ def resolve_artifact_plan(
                 normalize_version(xls_version),
             )
             if include_driver:
-                message = "{} and driver {}".format(message, normalize_version(driver_version))
+                message = "{} and driver {}".format(message, driver_identity)
             raise ValueError(message)
         plan = {
             "mode": "installed",
@@ -307,6 +535,9 @@ def resolve_artifact_plan(
         }
         if include_driver:
             plan["driver"] = installed_paths["driver"]
+            plan["driver_version"] = normalize_version(driver_version)
+            if driver_git_revision:
+                plan["driver_git_revision"] = normalize_git_revision(driver_git_revision)
         if local_xls_aot_runtime_source_path:
             plan["xls_aot_runtime_source"] = Path(local_xls_aot_runtime_source_path)
         return plan
@@ -318,18 +549,26 @@ def resolve_artifact_plan(
         plan["xls_aot_runtime_source"] = Path(local_xls_aot_runtime_source_path)
     if include_driver:
         plan["driver_version"] = normalize_version(driver_version)
+        if driver_git_revision:
+            plan["driver_git_revision"] = normalize_git_revision(driver_git_revision)
     return plan
 
 
 def resolve_driver_plan(
     artifact_source,
     driver_version,
+    driver_git_revision = "",
     installed_driver_root_prefix = "",
     local_driver_path = "",
     driver_input = "",
     exists_fn = os.path.exists,
 ):
+    if driver_version and driver_git_revision:
+        raise ValueError("xlsynth-driver materialization accepts either a release tag or a Git revision, not both")
+    driver_identity = normalize_git_revision(driver_git_revision) if driver_git_revision else normalize_version(driver_version)
     if artifact_source == "local_paths":
+        if driver_identity:
+            raise ValueError("local_paths does not accept xlsynth driver release or Git pins")
         if not local_driver_path:
             raise ValueError("local_paths driver materialization requires local_driver_path")
         if driver_input:
@@ -353,59 +592,73 @@ def resolve_driver_plan(
 
     if driver_input:
         if artifact_source == "auto":
-            if not driver_version:
-                raise ValueError("auto declared driver input requires xlsynth_driver_version")
-            return {
+            if not driver_identity:
+                raise ValueError("auto declared driver input requires an xlsynth driver release or Git pin")
+            plan = {
                 "mode": "auto_driver_input",
                 "driver": Path(driver_input),
                 "driver_version": normalize_version(driver_version),
                 "installed_driver_root_prefix": installed_driver_root_prefix,
             }
+            if driver_git_revision:
+                plan["driver_git_revision"] = normalize_git_revision(driver_git_revision)
+            return plan
         if artifact_source in ("auto", "installed_only"):
-            if not driver_version:
-                raise ValueError("{} declared driver input requires xlsynth_driver_version".format(artifact_source))
-            return {
+            if not driver_identity:
+                raise ValueError("{} declared driver input requires an xlsynth driver release or Git pin".format(artifact_source))
+            plan = {
                 "mode": "installed",
                 "driver": Path(driver_input),
                 "driver_version": normalize_version(driver_version),
             }
+            if driver_git_revision:
+                plan["driver_git_revision"] = normalize_git_revision(driver_git_revision)
+            return plan
         if artifact_source == "download_only":
             raise ValueError("download_only driver materialization does not accept driver_input")
         raise ValueError("Unknown artifact_source: {}".format(artifact_source))
 
     if artifact_source not in ("auto", "installed_only", "download_only"):
         raise ValueError("Unknown artifact_source: {}".format(artifact_source))
-    if not driver_version:
-        raise ValueError("{} driver materialization requires xlsynth_driver_version".format(artifact_source))
+    if not driver_identity:
+        raise ValueError("{} driver materialization requires an xlsynth driver release or Git pin".format(artifact_source))
     if artifact_source == "download_only":
         if installed_driver_root_prefix:
             raise ValueError("download_only driver materialization does not accept installed_driver_root_prefix")
-        return {
+        plan = {
             "mode": "download",
             "driver_version": normalize_version(driver_version),
         }
+        if driver_git_revision:
+            plan["driver_git_revision"] = normalize_git_revision(driver_git_revision)
+        return plan
 
     if not installed_driver_root_prefix:
         raise ValueError("{} driver materialization requires installed_driver_root_prefix".format(artifact_source))
 
-    normalized_driver_version = normalize_version(driver_version)
-    installed_driver = Path(installed_driver_root_prefix) / normalized_driver_version / "bin" / "xlsynth-driver"
+    installed_driver = Path(installed_driver_root_prefix) / driver_identity / "bin" / "xlsynth-driver"
     if exists_fn(str(installed_driver)):
-        return {
-            "mode": "installed",
+        plan = {
+            "mode": "auto_installed" if artifact_source == "auto" else "installed",
             "driver": installed_driver,
-            "driver_version": normalized_driver_version,
+            "driver_version": normalize_version(driver_version),
         }
+        if driver_git_revision:
+            plan["driver_git_revision"] = normalize_git_revision(driver_git_revision)
+        return plan
     if artifact_source == "installed_only":
         raise ValueError(
             "installed_only driver materialization requires installed path for driver {}".format(
-                normalized_driver_version,
+                driver_identity,
             )
         )
-    return {
+    plan = {
         "mode": "download",
-        "driver_version": normalized_driver_version,
+        "driver_version": normalize_version(driver_version),
     }
+    if driver_git_revision:
+        plan["driver_git_revision"] = normalize_git_revision(driver_git_revision)
+    return plan
 
 
 def derive_runtime_library_path(libxls_path):
@@ -469,12 +722,16 @@ def detect_host_platform():
     return "ubuntu2004"
 
 
-def driver_install_root(repo_root, driver_version, host_platform):
-    return repo_root / "_cargo_driver" / host_platform / normalize_version(driver_version)
+def driver_install_root(repo_root, driver_identity, host_platform):
+    return repo_root / "_cargo_driver" / host_platform / driver_identity
 
 
 def rustup_home_root(repo_root, host_platform):
     return repo_root / "_rustup_home" / host_platform
+
+
+def cargo_home_root(repo_root, host_platform):
+    return repo_root / "_cargo_home" / host_platform
 
 
 def cargo_target_root(repo_root, host_platform):
@@ -675,6 +932,24 @@ def build_driver_install_command(rustup_path, install_root, driver_version):
     ]
 
 
+def build_driver_git_install_command(rustup_path, install_root, driver_git_revision):
+    return [
+        rustup_path,
+        "run",
+        "nightly",
+        "cargo",
+        "install",
+        "--locked",
+        "--root",
+        str(install_root),
+        "--git",
+        _XLSYNTH_CRATE_REPO_URL,
+        "--rev",
+        normalize_git_revision(driver_git_revision),
+        "xlsynth-driver",
+    ]
+
+
 def build_rustup_toolchain_install_command(rustup_path):
     return [
         rustup_path,
@@ -701,6 +976,7 @@ def build_driver_install_environment(
     )
     resolved_host_platform = host_platform or detect_host_platform()
     env["RUSTUP_HOME"] = str(rustup_home_root(repo_root, resolved_host_platform))
+    env["CARGO_HOME"] = str(cargo_home_root(repo_root, resolved_host_platform))
     env["CARGO_TARGET_DIR"] = str(cargo_target_root(repo_root, resolved_host_platform))
     return env
 
@@ -720,7 +996,64 @@ def ensure_rustup_nightly_toolchain(rustup_path, env):
     )
 
 
-def validate_installed_driver(driver_path, env, driver_version):
+def sha256_file(path):
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as input_file:
+        for chunk in iter(lambda: input_file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def driver_git_provenance_path(driver_path):
+    return Path(driver_path).parent / _DRIVER_GIT_PROVENANCE_FILENAME
+
+
+def write_driver_git_provenance(driver_path, driver_git_revision):
+    revision = normalize_git_revision(driver_git_revision)
+    provenance = {
+        "schema_version": 1,
+        "source_repository": _XLSYNTH_CRATE_REPO_URL,
+        "git_revision": revision,
+        "driver_sha256": sha256_file(driver_path),
+    }
+    driver_git_provenance_path(driver_path).write_text(
+        json.dumps(provenance, indent = 2, sort_keys = True) + "\n",
+        encoding = "utf-8",
+    )
+
+
+def validate_driver_git_provenance(driver_path, driver_git_revision):
+    revision = normalize_git_revision(driver_git_revision)
+    provenance_path = driver_git_provenance_path(driver_path)
+    try:
+        provenance = json.loads(provenance_path.read_text(encoding = "utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise RuntimeError(
+            "Installed Git-pinned xlsynth-driver at {} requires valid provenance at {}".format(
+                driver_path,
+                provenance_path,
+            )
+        ) from error
+    expected = {
+        "schema_version": 1,
+        "source_repository": _XLSYNTH_CRATE_REPO_URL,
+        "git_revision": revision,
+        "driver_sha256": sha256_file(driver_path),
+    }
+    if provenance != expected:
+        raise RuntimeError(
+            "Installed Git-pinned xlsynth-driver provenance at {} does not match "
+            "the requested revision and driver bytes".format(provenance_path)
+        )
+
+
+def validate_installed_driver(
+        driver_path,
+        env,
+        driver_version = "",
+        driver_git_revision = ""):
+    if driver_version and driver_git_revision:
+        raise ValueError("installed driver validation accepts either a release tag or Git revision, not both")
     try:
         result = run_captured_text_command(
             [str(driver_path), "--version"],
@@ -739,7 +1072,7 @@ def validate_installed_driver(driver_path, env, driver_version):
         )
     version_text = "{}\n{}".format(result.stdout, result.stderr)
     expected_version = normalize_version(driver_version)
-    if expected_version not in version_text:
+    if expected_version and expected_version not in version_text:
         raise RuntimeError(
             "Installed xlsynth-driver at {} reported an unexpected version.\nexpected substring: {}\nstdout:\n{}\nstderr:\n{}".format(
                 driver_path,
@@ -748,12 +1081,30 @@ def validate_installed_driver(driver_path, env, driver_version):
                 result.stderr,
             )
         )
+    elif driver_git_revision:
+        validate_driver_git_provenance(driver_path, driver_git_revision)
 
 
-def install_driver(repo_root, driver_version, libxls_path, dslx_stdlib_path, rustup_path = ""):
+def install_driver(
+        repo_root,
+        driver_version,
+        libxls_path,
+        dslx_stdlib_path,
+        rustup_path = "",
+        driver_git_revision = ""):
+    if driver_version and driver_git_revision:
+        raise ValueError("xlsynth-driver install accepts either a release tag or a Git revision, not both")
+    driver_identity = (
+        normalize_git_revision(driver_git_revision)
+        if driver_git_revision
+        else normalize_version(driver_version)
+    )
+    if not driver_identity:
+        raise ValueError("xlsynth-driver install requires a release tag or Git revision")
     host_platform = detect_host_platform()
-    install_root = driver_install_root(repo_root, driver_version, host_platform)
+    install_root = driver_install_root(repo_root, driver_identity, host_platform)
     rustup_home = rustup_home_root(repo_root, host_platform)
+    cargo_home = cargo_home_root(repo_root, host_platform)
     target_root = cargo_target_root(repo_root, host_platform)
     env = build_driver_install_environment(
         repo_root,
@@ -761,12 +1112,17 @@ def install_driver(repo_root, driver_version, libxls_path, dslx_stdlib_path, rus
         dslx_stdlib_path,
         host_platform = host_platform,
     )
-    for path in [install_root, rustup_home, target_root]:
+    for path in [install_root, rustup_home, cargo_home, target_root]:
         path.mkdir(parents = True, exist_ok = True)
     driver_path = install_root / "bin" / "xlsynth-driver"
     if driver_path.exists():
         try:
-            validate_installed_driver(driver_path, env, driver_version)
+            validate_installed_driver(
+                driver_path,
+                env,
+                driver_version,
+                driver_git_revision,
+            )
             return driver_path
         except RuntimeError:
             ensure_clean_path(install_root)
@@ -776,16 +1132,31 @@ def install_driver(repo_root, driver_version, libxls_path, dslx_stdlib_path, rus
     if rustup is None:
         raise RuntimeError(
             "rules_xlsynth download fallback requires rustup to install xlsynth-driver {}".format(
-                driver_version
+                driver_identity
             )
         )
     ensure_rustup_nightly_toolchain(rustup, env)
+    if driver_git_revision:
+        install_command = build_driver_git_install_command(
+            rustup,
+            install_root,
+            driver_git_revision,
+        )
+    else:
+        install_command = build_driver_install_command(rustup, install_root, driver_version)
     subprocess.run(
-        build_driver_install_command(rustup, install_root, driver_version),
+        install_command,
         check = True,
         env = env,
     )
-    validate_installed_driver(driver_path, env, driver_version)
+    if driver_git_revision:
+        write_driver_git_provenance(driver_path, driver_git_revision)
+    validate_installed_driver(
+        driver_path,
+        env,
+        driver_version,
+        driver_git_revision,
+    )
     return driver_path
 
 
@@ -1035,9 +1406,23 @@ def stage_driver_probe_inputs(repo_root, resolved):
     return probe_paths
 
 
-def materialize_runtime_surface(repo_root, plan):
+def materialize_runtime_surface(repo_root, plan, resolved_identity = None):
     resolved = resolve_materialization_inputs(repo_root, plan)
+    colliding_runtime_files = sorted(
+        runtime_file.name
+        for runtime_file in resolved.get("runtime_files", [])
+        if runtime_file.name in _PRIVATE_RUNTIME_FILENAMES
+    )
+    if colliding_runtime_files:
+        raise ValueError(
+            "runtime payload uses reserved private filenames: {}".format(
+                ", ".join(colliding_runtime_files),
+            )
+        )
     stage_runtime_payload(repo_root, resolved)
+    ensure_clean_path(repo_root / "resolved_identity.json")
+    if resolved_identity is not None:
+        write_resolved_identity(repo_root, resolved_identity)
 
 
 def materialize_toolchain_surface(repo_root, plan):
@@ -1050,9 +1435,23 @@ def materialize_toolchain_surface(repo_root, plan):
             plan["driver_version"],
             probe_paths["libxls"],
             probe_paths["stdlib_root"],
+            driver_git_revision = plan.get("driver_git_revision", ""),
         )
     else:
         driver_path = resolved["driver"]
+        if (
+            plan["mode"] == "installed"
+            and (plan.get("driver_version") or plan.get("driver_git_revision"))
+        ):
+            validate_installed_driver(
+                driver_path,
+                build_driver_environment(
+                    probe_paths["libxls"],
+                    probe_paths["stdlib_root"],
+                ),
+                plan.get("driver_version", ""),
+                plan.get("driver_git_revision", ""),
+            )
 
     driver_dest = repo_root / "xlsynth-driver"
     symlink_or_copy(driver_path, driver_dest)
@@ -1073,20 +1472,22 @@ def materialize_driver_binary(
         dslx_stdlib_path,
         rustup_path = ""):
     driver_env = build_driver_environment(libxls_path, dslx_stdlib_path)
-    if plan["mode"] == "auto_driver_input":
+    if plan["mode"] in ("auto_driver_input", "auto_installed"):
         try:
             validate_installed_driver(
                 plan["driver"],
                 driver_env,
                 plan["driver_version"],
+                plan.get("driver_git_revision", ""),
             )
             driver_path = plan["driver"]
         except RuntimeError:
-            fallback_plan = resolve_driver_plan(
-                artifact_source = "auto",
-                driver_version = plan["driver_version"],
-                installed_driver_root_prefix = plan["installed_driver_root_prefix"],
-            )
+            fallback_plan = {
+                "mode": "download",
+                "driver_version": plan["driver_version"],
+            }
+            if plan.get("driver_git_revision"):
+                fallback_plan["driver_git_revision"] = plan["driver_git_revision"]
             materialize_driver_binary(
                 repo_root,
                 fallback_plan,
@@ -1103,6 +1504,7 @@ def materialize_driver_binary(
             libxls_path,
             dslx_stdlib_path,
             rustup_path = rustup_path,
+            driver_git_revision = plan.get("driver_git_revision", ""),
         )
     else:
         driver_path = plan["driver"]
@@ -1111,11 +1513,126 @@ def materialize_driver_binary(
                 driver_path,
                 driver_env,
                 plan["driver_version"],
+                plan.get("driver_git_revision", ""),
             )
 
     driver_output.parent.mkdir(parents = True, exist_ok = True)
     copy_path(driver_path, driver_output)
     driver_output.chmod(driver_output.stat().st_mode | 0o111)
+
+
+def validate_and_copy_driver_resolved_identity(
+        identity_input,
+        identity_output,
+        plan,
+        allow_xls_pin_mismatch = False):
+    identity = json.loads(Path(identity_input).read_text(encoding = "utf-8"))
+    required_fields = {
+        "schema_version",
+        "xlsynth_crate_pin",
+        "xls_pin",
+        "resolved_xlsynth_crate_revision",
+        "crate_implied_xls_release_tag",
+        "resolved_xls_release_tag",
+        "resolved_xls_revision",
+    }
+    if set(identity) != required_fields:
+        raise ValueError(
+            "resolved identity fields {} do not match required schema fields {}".format(
+                sorted(identity),
+                sorted(required_fields),
+            )
+        )
+    if identity["schema_version"] != 1:
+        raise ValueError(
+            "resolved identity schema_version {} is unsupported".format(
+                identity["schema_version"],
+            )
+        )
+    for field in ["xlsynth_crate_pin", "xls_pin"]:
+        pin = identity[field]
+        if (
+            not isinstance(pin, dict)
+            or set(pin) != {"kind", "value"}
+            or pin.get("kind") not in ("release_tag", "git_revision")
+            or not isinstance(pin.get("value"), str)
+            or not pin["value"]
+        ):
+            raise ValueError("resolved identity {} is malformed: {}".format(field, pin))
+        if pin["kind"] == "release_tag":
+            if pin["value"] != normalize_release_tag(pin["value"]):
+                raise ValueError(
+                    "resolved identity {} release tag is malformed: {}".format(field, pin["value"])
+                )
+            if field == "xls_pin" and not _XLS_RELEASE_TAG_RE.fullmatch(pin["value"]):
+                raise ValueError(
+                    "resolved identity {} is not an XLS release tag: {}".format(
+                        field,
+                        pin["value"],
+                    )
+                )
+        elif pin["value"] != normalize_git_revision(pin["value"]):
+            raise ValueError(
+                "resolved identity {} Git revision must be a lowercase exact SHA".format(field)
+            )
+    for field in ["resolved_xlsynth_crate_revision", "resolved_xls_revision"]:
+        revision = identity[field]
+        if (
+            not isinstance(revision, str)
+            or len(revision) != 40
+            or any(character not in "0123456789abcdef" for character in revision)
+        ):
+            raise ValueError(
+                "resolved identity {} is not a lowercase 40-character Git SHA".format(field)
+            )
+    for field in ["crate_implied_xls_release_tag", "resolved_xls_release_tag"]:
+        release_tag = identity[field]
+        if not isinstance(release_tag, str) or not _XLS_RELEASE_TAG_RE.fullmatch(release_tag):
+            raise ValueError("resolved identity {} is not an XLS release tag".format(field))
+    expected_pin = producer_pin(
+        plan.get("driver_version", ""),
+        plan.get("driver_git_revision", ""),
+        "xlsynth-driver materialization pin",
+    )
+    if identity.get("xlsynth_crate_pin") != expected_pin:
+        raise ValueError(
+            "resolved identity xlsynth-crate pin {} does not match selected driver pin {}".format(
+                identity.get("xlsynth_crate_pin"),
+                expected_pin,
+            )
+        )
+    # Release tag-to-SHA mappings were resolved before the private runtime
+    # repository was generated; this action verifies all local relationships.
+    crate_pin = identity["xlsynth_crate_pin"]
+    if (
+        crate_pin["kind"] == "git_revision"
+        and crate_pin["value"] != identity["resolved_xlsynth_crate_revision"]
+    ):
+        raise ValueError(
+            "resolved identity xlsynth-crate Git pin does not match "
+            "resolved_xlsynth_crate_revision"
+        )
+    xls_pin = identity["xls_pin"]
+    if xls_pin["kind"] == "git_revision":
+        if xls_pin["value"] != identity["resolved_xls_revision"]:
+            raise ValueError(
+                "resolved identity XLS Git pin does not match resolved_xls_revision"
+            )
+    elif xls_pin["value"] != identity["resolved_xls_release_tag"]:
+        raise ValueError(
+            "resolved identity XLS release pin does not match resolved_xls_release_tag"
+        )
+    if (
+        not allow_xls_pin_mismatch
+        and identity["crate_implied_xls_release_tag"] != identity["resolved_xls_release_tag"]
+    ):
+        raise ValueError(
+            "resolved identity crate-implied XLS release does not match "
+            "the resolved XLS release without an explicit development override"
+        )
+    identity_output = Path(identity_output)
+    identity_output.parent.mkdir(parents = True, exist_ok = True)
+    copy_path(Path(identity_input), identity_output)
 
 
 def parse_args(argv):
@@ -1124,7 +1641,11 @@ def parse_args(argv):
     parser.add_argument("--artifact-source", required = True)
     parser.add_argument("--surface", required = True, choices = ["runtime", "toolchain"])
     parser.add_argument("--xls-version", default = "")
+    parser.add_argument("--xls-git-revision", default = "")
     parser.add_argument("--xlsynth-driver-version", default = "")
+    parser.add_argument("--xlsynth-driver-git-revision", default = "")
+    parser.add_argument("--emit-resolved-identity", action = "store_true")
+    parser.add_argument("--allow-xls-pin-mismatch", action = "store_true")
     parser.add_argument("--installed-tools-root-prefix", default = "")
     parser.add_argument("--installed-driver-root-prefix", default = "")
     parser.add_argument("--local-tools-path", default = "")
@@ -1135,6 +1656,8 @@ def parse_args(argv):
     parser.add_argument("--driver-input", default = "")
     parser.add_argument("--driver-runtime-libxls", default = "")
     parser.add_argument("--driver-runtime-stdlib", default = "")
+    parser.add_argument("--driver-resolved-identity-input", default = "")
+    parser.add_argument("--driver-resolved-identity-output", default = "")
     parser.add_argument("--rustup-path", default = "")
     parser.add_argument("--local-xls-aot-runtime-path", default = "")
     parser.add_argument("--local-xls-aot-runtime-link-config-path", default = "")
@@ -1152,6 +1675,7 @@ def main(argv):
         driver_plan = resolve_driver_plan(
             artifact_source = args.artifact_source,
             driver_version = args.xlsynth_driver_version,
+            driver_git_revision = args.xlsynth_driver_git_revision,
             installed_driver_root_prefix = args.installed_driver_root_prefix,
             local_driver_path = args.local_driver_path,
             driver_input = args.driver_input,
@@ -1164,11 +1688,44 @@ def main(argv):
             Path(args.driver_runtime_stdlib).resolve(),
             rustup_path = args.rustup_path,
         )
+        if bool(args.driver_resolved_identity_input) != bool(args.driver_resolved_identity_output):
+            raise ValueError(
+                "--driver-resolved-identity-input and --driver-resolved-identity-output are required together"
+            )
+        if args.driver_resolved_identity_input:
+            validate_and_copy_driver_resolved_identity(
+                args.driver_resolved_identity_input,
+                args.driver_resolved_identity_output,
+                driver_plan,
+                allow_xls_pin_mismatch = args.allow_xls_pin_mismatch,
+            )
         return
+    resolved_identity = None
+    materialized_xls_version = args.xls_version
+    if args.xls_version and args.xls_git_revision:
+        raise ValueError("XLS materialization accepts either a release tag or Git revision, not both")
+    if args.emit_resolved_identity:
+        validate_resolved_identity_inputs(
+            args.artifact_source,
+            args.local_xls_aot_runtime_source_path,
+        )
+        resolved_identity = resolve_archive_identity(
+            xls_version = args.xls_version,
+            xls_git_revision = args.xls_git_revision,
+            driver_version = args.xlsynth_driver_version,
+            driver_git_revision = args.xlsynth_driver_git_revision,
+            allow_xls_pin_mismatch = args.allow_xls_pin_mismatch,
+        )
+        materialized_xls_version = resolved_identity["resolved_xls_release_tag"]
+    elif args.xls_git_revision:
+        materialized_xls_version = resolve_xls_pin(
+            producer_pin("", args.xls_git_revision, "XLS pin"),
+        )["release_tag"]
     plan = resolve_artifact_plan(
         artifact_source = args.artifact_source,
-        xls_version = args.xls_version,
+        xls_version = materialized_xls_version,
         driver_version = args.xlsynth_driver_version,
+        driver_git_revision = args.xlsynth_driver_git_revision,
         surface = args.surface,
         installed_tools_root_prefix = args.installed_tools_root_prefix,
         installed_driver_root_prefix = args.installed_driver_root_prefix,
@@ -1180,8 +1737,12 @@ def main(argv):
         local_xls_aot_runtime_link_config_path = args.local_xls_aot_runtime_link_config_path,
         local_xls_aot_runtime_source_path = args.local_xls_aot_runtime_source_path,
     )
+    if args.xlsynth_driver_git_revision:
+        if args.artifact_source == "local_paths":
+            raise ValueError("local_paths does not accept xlsynth driver Git pins")
+        plan["driver_git_revision"] = normalize_git_revision(args.xlsynth_driver_git_revision)
     if args.surface == "runtime":
-        materialize_runtime_surface(repo_root, plan)
+        materialize_runtime_surface(repo_root, plan, resolved_identity = resolved_identity)
     else:
         materialize_toolchain_surface(repo_root, plan)
 

--- a/materialize_xls_bundle.py
+++ b/materialize_xls_bundle.py
@@ -958,6 +958,7 @@ def build_rustup_toolchain_install_command(rustup_path):
         "nightly",
         "--profile",
         "minimal",
+        "--no-self-update",
     ]
 
 

--- a/registered_toolchain_smoke.py
+++ b/registered_toolchain_smoke.py
@@ -535,6 +535,38 @@ class RegisteredRuntimeOnlyTest(unittest.TestCase):
         self.assertNotIn("rustup", combined_output)
         self.assertNotIn("cargo", combined_output.lower())
 
+    def test_01_local_driver_package_load_advertises_current_flags(self):
+        bazel_path = shutil.which("bazel")
+        if bazel_path == None:
+            self.skipTest("bazel is not on PATH")
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            local_driver = root / "local_driver" / "xlsynth-driver"
+            local_driver.parent.mkdir()
+            write_text_file(
+                local_driver,
+                "#!/bin/sh\nprintf 'local driver should not run during query\\n' >&2\nexit 42\n",
+                0o755,
+            )
+            workspace_root = self.create_nested_workspace(root, local_driver)
+            env = dict(os.environ)
+            env["PATH"] = minimal_tool_path_env(bazel_path)
+            output_user_root = root / "bazel_output_user_root"
+            result = run_nested_bazel(
+                bazel_path,
+                output_user_root,
+                workspace_root,
+                env,
+                ["query", "--output=build", "@lazy_xls_toolchain//:bundle"],
+            )
+
+        combined_output = "{}\n{}".format(result.stdout, result.stderr)
+        self.assertEqual(result.returncode, 0, combined_output)
+        self.assertIn("driver_supports_sv_enum_case_naming_policy = True", result.stdout)
+        self.assertIn("driver_supports_sv_struct_field_ordering = True", result.stdout)
+        self.assertNotIn("local driver should not run during query", combined_output)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/registered_toolchain_smoke.py
+++ b/registered_toolchain_smoke.py
@@ -522,12 +522,14 @@ class RegisteredRuntimeOnlyTest(unittest.TestCase):
                 output_user_root,
                 workspace_root,
                 env,
-                ["query", "@lazy_xls_toolchain//:all"],
+                ["query", "--output=build", "@lazy_xls_toolchain//:bundle"],
             )
 
         combined_output = "{}\n{}".format(result.stdout, result.stderr)
         self.assertEqual(result.returncode, 0, combined_output)
         self.assertIn("@lazy_xls_toolchain//:xlsynth-driver", combined_output)
+        self.assertIn("driver_supports_sv_enum_case_naming_policy = False", result.stdout)
+        self.assertIn("driver_supports_sv_struct_field_ordering = False", result.stdout)
         self.assertNotIn("Installing xlsynth-driver", combined_output)
         self.assertNotIn("Compiling xlsynth-driver", combined_output)
         self.assertNotIn("rustup", combined_output)

--- a/run_presubmit.py
+++ b/run_presubmit.py
@@ -442,6 +442,7 @@ def run_toolchain_helper_tests(config: PresubmitConfig):
             '//:artifact_resolution_test',
             '//:download_release_test',
             '//:external_bundle_exports_test',
+            '//:trusted_identity_boundary_test',
         ),
         config,
     )

--- a/trusted_identity_boundary_test.bzl
+++ b/trusted_identity_boundary_test.bzl
@@ -1,0 +1,65 @@
+"""Analysis tests for the trusted resolved-identity construction boundary."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("//:xls_toolchain.bzl", "XlsRuntimeSurfaceInfo", "xlsynth_driver_binary")
+
+def _fake_runtime_impl(ctx):
+    artifact = ctx.file.artifact
+    return [
+        XlsRuntimeSurfaceInfo(
+            artifact_inputs = [artifact],
+            dslx_stdlib = artifact,
+            dslx_stdlib_path = artifact.path,
+            libxls = artifact,
+            runtime_files = [],
+            runtime_library_path = artifact.dirname,
+            tools_root = artifact,
+            tools_path = artifact.dirname,
+            xls_aot_runtime = None,
+        ),
+        DefaultInfo(files = depset([artifact])),
+    ]
+
+_fake_runtime = rule(
+    implementation = _fake_runtime_impl,
+    attrs = {
+        "artifact": attr.label(allow_single_file = True, mandatory = True),
+    },
+)
+
+def _forged_identity_is_rejected_impl(ctx):
+    env = analysistest.begin(ctx)
+    asserts.expect_failure(
+        env,
+        "trusted resolved identity requires an extension-generated *_toolchain repository",
+    )
+    return analysistest.end(env)
+
+_forged_identity_is_rejected_test = analysistest.make(
+    _forged_identity_is_rejected_impl,
+    expect_failure = True,
+)
+
+def trusted_identity_boundary_test_suite(name):
+    """Instantiates the trusted identity boundary analysis test.
+
+    Args:
+      name: Test target name.
+    """
+    runtime_name = name + "_runtime"
+    driver_name = name + "_driver"
+    _fake_runtime(
+        name = runtime_name,
+        artifact = "//:LICENSE",
+    )
+    xlsynth_driver_binary(
+        name = driver_name,
+        action_path = "/usr/bin",
+        artifact_source = "download_only",
+        resolved_identity = "//:LICENSE",
+        runtime = ":" + runtime_name,
+    )
+    _forged_identity_is_rejected_test(
+        name = name,
+        target_under_test = ":" + driver_name,
+    )

--- a/xls_toolchain.bzl
+++ b/xls_toolchain.bzl
@@ -1,3 +1,5 @@
+"""Defines XLS artifact bundles, registered toolchains, and action helpers."""
+
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
 load("@rules_cc//cc:defs.bzl", "CcInfo", "cc_common")
@@ -17,9 +19,19 @@ XlsArtifactBundleInfo = provider(
         "libxls": "The libxls shared library file.",
         "runtime_files": "Declared runtime files needed to load libxls.",
         "runtime_library_path": "Directory containing libxls for runtime loading.",
+        "resolved_identity": "Machine-readable resolved producer identity manifest, when requested.",
         "tools_root": "The XLS tool root tree artifact.",
         "tools_path": "Directory path containing the XLS tool binaries.",
         "xls_aot_runtime": "The standalone AOT static runtime archive.",
+    },
+)
+
+_XlsynthDriverBinaryInfo = provider(
+    doc = "Generated xlsynth-driver artifact and its trusted producer identity, when requested.",
+    fields = {
+        "driver": "The generated xlsynth-driver binary.",
+        "resolved_identity": "Driver-validated producer identity sidecar.",
+        "runtime_label": "Runtime target whose artifacts were used to materialize the driver.",
     },
 )
 
@@ -89,6 +101,7 @@ def _bundle_struct_from_provider(bundle):
         libxls = bundle.libxls,
         runtime_files = bundle.runtime_files,
         runtime_library_path = bundle.runtime_library_path,
+        resolved_identity = bundle.resolved_identity,
         tools_root = bundle.tools_root,
         tools_path = bundle.tools_path,
         xls_aot_runtime = bundle.xls_aot_runtime,
@@ -127,6 +140,7 @@ def _toolchain_with_semantics(artifact_selection, ctx):
         libxls = artifact_selection.libxls,
         runtime_files = artifact_selection.runtime_files,
         runtime_library_path = artifact_selection.runtime_library_path,
+        resolved_identity = artifact_selection.resolved_identity,
         driver_supports_sv_enum_case_naming_policy = artifact_selection.driver_supports_sv_enum_case_naming_policy,
         driver_supports_sv_struct_field_ordering = artifact_selection.driver_supports_sv_struct_field_ordering,
         dslx_path = _split_nonempty(ctx.attr._dslx_path_flag[BuildSettingInfo].value, ":"),
@@ -198,15 +212,70 @@ xls_runtime_surface = rule(
     },
 )
 
+def _validate_trusted_identity_binding(ctx, resolved_identity):
+    driver_label = ctx.label
+    runtime_label = ctx.attr.runtime.label
+    identity_label = ctx.attr.resolved_identity.label
+    toolchain_repository = driver_label.repo_name
+    runtime_repository = runtime_label.repo_name
+    identity_repository = identity_label.repo_name
+
+    if ctx.attr.artifact_source != "download_only":
+        fail("trusted resolved identity requires artifact_source=download_only")
+    if (
+        not toolchain_repository or
+        "+" not in toolchain_repository or
+        not toolchain_repository.endswith("_toolchain")
+    ):
+        fail(
+            "trusted resolved identity requires an extension-generated " +
+            "*_toolchain repository",
+        )
+    expected_runtime_repository = toolchain_repository[:-len("_toolchain")] + "_runtime"
+    if runtime_repository != expected_runtime_repository:
+        fail(
+            "trusted resolved identity requires the runtime repository paired " +
+            "with the extension-generated toolchain repository",
+        )
+    if identity_repository != runtime_repository:
+        fail(
+            "trusted resolved identity must come from the same extension-generated " +
+            "runtime repository as the selected runtime",
+        )
+    if driver_label.package != "" or driver_label.name != "xlsynth-driver":
+        fail("trusted resolved identity requires the generated //:xlsynth-driver target")
+    if runtime_label.package != "" or runtime_label.name != "runtime":
+        fail("trusted resolved identity requires the generated runtime //:runtime target")
+    if identity_label.package != "" or identity_label.name != "resolved_identity_for_toolchain":
+        fail(
+            "trusted resolved identity requires the generated " +
+            "runtime //:resolved_identity_for_toolchain target",
+        )
+    if resolved_identity.basename != "resolved_identity.json":
+        fail("trusted resolved identity source must be named resolved_identity.json")
+
 def _xlsynth_driver_binary_impl(ctx):
     runtime = _runtime_struct_from_provider(ctx.attr.runtime[XlsRuntimeSurfaceInfo])
     output = ctx.actions.declare_file(ctx.label.name)
-    host_driver_inputs = [ctx.file.host_driver] if ctx.file.host_driver else []
+    resolved_identity = ctx.file.resolved_identity
+    if resolved_identity:
+        _validate_trusted_identity_binding(ctx, resolved_identity)
+    identity_output = (
+        ctx.actions.declare_file(ctx.label.name + ".resolved_identity.json") if resolved_identity else None
+    )
+    if ctx.file.host_driver_provenance and not ctx.file.host_driver:
+        fail("host_driver_provenance requires host_driver")
+    host_driver_inputs = (
+        [ctx.file.host_driver, ctx.file.host_driver_provenance] if ctx.file.host_driver_provenance else [ctx.file.host_driver] if ctx.file.host_driver else []
+    )
+    identity_inputs = [resolved_identity] if resolved_identity else []
     action_inputs = _dedupe_artifacts(
         [ctx.file._materializer, runtime.libxls, runtime.dslx_stdlib] +
         host_driver_inputs +
-        runtime.runtime_files
+        identity_inputs +
+        runtime.runtime_files,
     )
+    action_outputs = [output] + ([identity_output] if identity_output else [])
     action_env = {"PATH": ctx.attr.action_path}
     if ctx.attr.action_ld_library_path:
         action_env["LD_LIBRARY_PATH"] = ctx.attr.action_ld_library_path
@@ -220,7 +289,7 @@ def _xlsynth_driver_binary_impl(ctx):
         action_env["RUSTUP_HOME"] = ctx.attr.action_rustup_home
     ctx.actions.run_shell(
         inputs = action_inputs,
-        outputs = [output],
+        outputs = action_outputs,
         arguments = [
             ctx.file._materializer.path,
             output.path,
@@ -228,10 +297,14 @@ def _xlsynth_driver_binary_impl(ctx):
             runtime.dslx_stdlib.path,
             ctx.attr.artifact_source,
             ctx.attr.xlsynth_driver_version,
+            ctx.attr.xlsynth_driver_git_revision,
             ctx.attr.installed_driver_root_prefix,
             ctx.attr.local_driver_path,
             ctx.attr.rustup_path,
             ctx.file.host_driver.path if ctx.file.host_driver else "",
+            resolved_identity.path if resolved_identity else "",
+            identity_output.path if identity_output else "",
+            "true" if ctx.attr.allow_xls_pin_mismatch else "false",
         ],
         command = """
             set -euo pipefail
@@ -241,10 +314,14 @@ def _xlsynth_driver_binary_impl(ctx):
             runtime_stdlib="$4"
             artifact_source="$5"
             driver_version="$6"
-            installed_driver_root_prefix="$7"
-            local_driver_path="$8"
-            rustup_path="$9"
-            host_driver="${10}"
+            driver_git_revision="$7"
+            installed_driver_root_prefix="$8"
+            local_driver_path="$9"
+            rustup_path="${10}"
+            host_driver="${11}"
+            resolved_identity_input="${12}"
+            resolved_identity_output="${13}"
+            allow_xls_pin_mismatch="${14}"
 
             work="${TMPDIR:-/tmp}/rules_xlsynth_driver_${RANDOM}"
             rm -rf "$work"
@@ -264,6 +341,9 @@ def _xlsynth_driver_binary_impl(ctx):
             if [[ -n "$driver_version" ]]; then
                 command+=(--xlsynth-driver-version "$driver_version")
             fi
+            if [[ -n "$driver_git_revision" ]]; then
+                command+=(--xlsynth-driver-git-revision "$driver_git_revision")
+            fi
             if [[ -n "$installed_driver_root_prefix" ]]; then
                 command+=(--installed-driver-root-prefix "$installed_driver_root_prefix")
             fi
@@ -276,16 +356,32 @@ def _xlsynth_driver_binary_impl(ctx):
             if [[ -n "$rustup_path" ]]; then
                 command+=(--rustup-path "$rustup_path")
             fi
+            if [[ -n "$resolved_identity_input" ]]; then
+                command+=(
+                    --driver-resolved-identity-input "$resolved_identity_input"
+                    --driver-resolved-identity-output "$resolved_identity_output"
+                )
+                if [[ "$allow_xls_pin_mismatch" == "true" ]]; then
+                    command+=(--allow-xls-pin-mismatch)
+                fi
+            fi
             "${command[@]}"
         """,
         env = action_env,
         progress_message = "Materializing xlsynth-driver for {}".format(ctx.label),
         mnemonic = "XlsynthDriverBinary",
     )
-    return DefaultInfo(
-        files = depset(direct = [output]),
-        executable = output,
-    )
+    return [
+        _XlsynthDriverBinaryInfo(
+            driver = output,
+            resolved_identity = identity_output,
+            runtime_label = ctx.attr.runtime.label,
+        ),
+        DefaultInfo(
+            files = depset(direct = [output]),
+            executable = output,
+        ),
+    ]
 
 xlsynth_driver_binary = rule(
     implementation = _xlsynth_driver_binary_impl,
@@ -296,13 +392,17 @@ xlsynth_driver_binary = rule(
         "action_ld_library_path": attr.string(),
         "action_path": attr.string(mandatory = True),
         "action_rustup_home": attr.string(),
+        "allow_xls_pin_mismatch": attr.bool(),
         "artifact_source": attr.string(mandatory = True),
         "host_driver": attr.label(allow_single_file = True),
+        "host_driver_provenance": attr.label(allow_single_file = True),
         "installed_driver_root_prefix": attr.string(),
         "local_driver_path": attr.string(),
+        "resolved_identity": attr.label(allow_single_file = True),
         "runtime": attr.label(mandatory = True, providers = [XlsRuntimeSurfaceInfo]),
         "rustup_path": attr.string(),
         "xlsynth_driver_version": attr.string(),
+        "xlsynth_driver_git_revision": attr.string(),
         "_materializer": attr.label(
             default = Label("//:materialize_xls_bundle.py"),
             allow_single_file = True,
@@ -314,7 +414,16 @@ xlsynth_driver_binary = rule(
 def _xls_bundle_impl(ctx):
     runtime = _runtime_struct_from_provider(ctx.attr.runtime[XlsRuntimeSurfaceInfo])
     driver = _single_artifact(ctx.attr.driver, "driver")
+    driver_identity = (
+        ctx.attr.driver[_XlsynthDriverBinaryInfo] if _XlsynthDriverBinaryInfo in ctx.attr.driver else None
+    )
+    if driver_identity != None and driver_identity.resolved_identity:
+        if driver_identity.runtime_label != ctx.attr.runtime.label:
+            fail("identity-bearing xlsynth_driver_binary requires its matching runtime")
+    resolved_identity = driver_identity.resolved_identity if driver_identity != None else None
     artifact_inputs = _dedupe_artifacts(runtime.artifact_inputs + [driver])
+    if resolved_identity:
+        artifact_inputs = _dedupe_artifacts(artifact_inputs + [resolved_identity])
     return [
         XlsArtifactBundleInfo(
             artifact_inputs = artifact_inputs,
@@ -326,6 +435,7 @@ def _xls_bundle_impl(ctx):
             libxls = runtime.libxls,
             runtime_files = runtime.runtime_files,
             runtime_library_path = runtime.runtime_library_path,
+            resolved_identity = resolved_identity,
             tools_root = runtime.tools_root,
             tools_path = runtime.tools_path,
             xls_aot_runtime = runtime.xls_aot_runtime,
@@ -365,6 +475,7 @@ def _merge_toolchain_with_bundle(toolchain, bundle):
         libxls = artifact_selection.libxls,
         runtime_files = artifact_selection.runtime_files,
         runtime_library_path = artifact_selection.runtime_library_path,
+        resolved_identity = artifact_selection.resolved_identity,
         tools_root = artifact_selection.tools_root,
         tools_path = artifact_selection.tools_path,
         dslx_path = toolchain.dslx_path,
@@ -377,6 +488,14 @@ def _merge_toolchain_with_bundle(toolchain, bundle):
     )
 
 def require_driver_toolchain(ctx):
+    """Returns the selected driver-capable XLS toolchain.
+
+    Args:
+      ctx: Rule context with XLS toolchain access.
+
+    Returns:
+      The selected XLS toolchain.
+    """
     toolchain = get_xls_toolchain(ctx)
     if not toolchain.driver_path:
         fail("rules_xlsynth requires a configured xlsynth-driver")
@@ -421,6 +540,21 @@ def declare_xls_toolchain_toml(
         use_system_verilog = "",
         add_invariant_assertions = "",
         array_index_bounds_checking = ""):
+    """Declares a toolchain TOML file for the selected XLS bundle.
+
+    Args:
+      ctx: Rule context used to declare the output.
+      name: Stable output-name component.
+      toolchain: Optional already-selected XLS toolchain.
+      gate_format: Optional codegen gate format override.
+      assert_format: Optional codegen assertion format override.
+      use_system_verilog: Optional tri-state SystemVerilog override.
+      add_invariant_assertions: Optional tri-state invariant assertion override.
+      array_index_bounds_checking: Optional array-bounds-checking override.
+
+    Returns:
+      The declared toolchain TOML file.
+    """
     resolved_toolchain = require_tools_toolchain(ctx) if toolchain == None else toolchain
 
     resolved_use_system_verilog = _resolve_tri_state(resolved_toolchain.use_system_verilog, use_system_verilog)


### PR DESCRIPTION
## Summary

- Materializes xlsynth-crate and XLS from typed release or exact-revision pins, so consumers can request the producer pair they mean.
- Exposes one resolved identity manifest through `XlsArtifactBundleInfo` for generated download-only bundles.
- Rejects authoritative identity requests that point at local or installed artifacts that `rules_xlsynth` did not materialize.

## Problem Solved

Auto-SPO archive IDs need to be reproducible: a structural ID should say which xlsynth driver and XLS runtime actually produced it. Version labels alone are not enough if execution can come from an unrelated local or preinstalled bundle.

## Example

```text
requested: xlsynth-crate Git revision A, XLS release B
rules_xlsynth materializes both inputs
  -> writes resolved identity manifest {crate: A, xls: B}
  -> exposes that manifest to Bazel consumers

requested: trusted identity from an existing local driver
  -> reject, because rules_xlsynth did not create that producer bundle
```

## Compatibility

Existing local and installed bundle modes remain available for ordinary non-identity consumers. Only archive-authoritative identity requires the paired generated download-only runtime and toolchain graph.

## Validation

- Python materializer coverage exercises release pins, Git pins, exact XLS-SHA-to-release matching, deliberately different crate and XLS versions, and identity-mode rejection paths.
- Bazel trusted-boundary coverage verifies generated bundle identity exposure and rejects non-generated authoritative identity.
- Selftest cquery coverage confirms the generated `xlsynth-driver` toolchain label remains resolvable.

<!-- spr-stack:start -->
**Stack**:
- ➡ #61

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->
