### PR TITLE
Remove support for old aot compiler.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -113,9 +113,9 @@ py_test(
         ":xlsynth_sys_dep_probe",
         ":xlsynth_sys_legacy_inputs_probe",
         ":xlsynth_sys_runtime_probe",
+        "@rules_xlsynth_selftest_xls_toolchain",
         "@rules_xlsynth_selftest_xls_runtime//:dslx_stdlib",
         "@rules_xlsynth_selftest_xls_runtime//:xlsynth_sys_artifact_config",
-        "@rules_xlsynth_selftest_xls_toolchain",
     ],
     deps = ["@rules_python//python/runfiles"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -113,9 +113,9 @@ py_test(
         ":xlsynth_sys_dep_probe",
         ":xlsynth_sys_legacy_inputs_probe",
         ":xlsynth_sys_runtime_probe",
-        "@rules_xlsynth_selftest_xls_toolchain",
         "@rules_xlsynth_selftest_xls_runtime//:dslx_stdlib",
         "@rules_xlsynth_selftest_xls_runtime//:xlsynth_sys_artifact_config",
+        "@rules_xlsynth_selftest_xls_toolchain",
     ],
     deps = ["@rules_python//python/runfiles"],
 )

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -12,8 +12,7 @@ flags.
 
 Each `xls.toolchain(...)` call exposes one runtime repo and one toolchain repo.
 `@<name>_runtime` contains the selected tool binaries, the DSLX stdlib tree,
-the matching `libxls` shared library, the standalone AOT static runtime archive
-when that XLS line provides one, and the runtime-facing exports.
+the matching `libxls` shared library, and the runtime-facing exports.
 `@<name>_toolchain` contains the `:bundle` target, the registered toolchain
 target, and a declared `:xlsynth-driver` target. Loading or registering the
 toolchain repo is metadata-only; the driver target copies, validates,
@@ -23,9 +22,6 @@ is:
 
 - `@<name>_runtime//:libxls`
 - `@<name>_runtime//:libxls_link`
-- `@<name>_runtime//:xls_aot_runtime` when the selected XLS line provides the archive
-- `@<name>_runtime//:xls_aot_runtime_file` when the selected XLS line provides the archive
-- `@<name>_runtime//:xls_aot_runtime_link_config_file` when the selected XLS line provides the archive
 - `@<name>_runtime//:dslx_stdlib`
 - `@<name>_runtime//:xlsynth_sys_artifact_config`
 - `@<name>_runtime//:xlsynth_sys_legacy_stdlib`
@@ -50,11 +46,7 @@ The `xlsynth_sys_*` exports are the intended downstream contract for
 `rules_rust` `crate_extension.annotation(...)` wiring. The preferred modern
 shape is `build_script_data` / `build_script_env` for the build-script
 contract, plus `deps = ["@<name>_runtime//:xlsynth_sys_dep"]` for the combined
-runtime-plus-link contract. `xlsynth-aot-runtime` reuses the same artifact
-config file so its build script can find the matching standalone runtime archive
-without a parallel bundle surface. Bundle lines that predate the archive may
-omit it; that preserves non-AOT consumers while still causing an AOT build to
-fail if it selects an archive-less bundle. The compatibility exports
+runtime-plus-link contract. The compatibility exports
 `xlsynth_sys_runtime_files` and `xlsynth_sys_link_dep` remain available for
 callers that still spell those phases separately. This lets root `MODULE.bazel`
 files choose only a bundle and a build-script mode instead of coupling to
@@ -108,8 +100,7 @@ does not resolve to the crate-implied XLS release.
 overrides. Trusted identity emission requires `artifact_source =
 "download_only"`: the installed-layout modes intentionally trust
 consumer-owned directories and therefore cannot mint an authoritative archive
-identity. It also rejects `local_xls_aot_runtime_source_path`, because those
-source bytes are not covered by the resolved XLS identity.
+identity.
 
 An exact `xlsynth_driver_git_revision` is materialized by Cargo
 `--git ... --rev <SHA>`. Reusing an installed Git-pinned driver additionally

--- a/README.md
+++ b/README.md
@@ -72,8 +72,7 @@ are resolved at different times:
   `xls_version` or `xls_git_revision`. A driver-backed bundle similarly requires
   exactly one `xlsynth_driver_version` or `xlsynth_driver_git_revision`.
 - `local_paths` does not accept `xls_version` or `xlsynth_driver_version`;
-  the other modes accept no local artifact overrides except
-  `local_xls_aot_runtime_source_path`.
+  the other modes accept no local artifact overrides.
 - `download_only` does not accept any `installed_*` attrs.
 
 For provenance-sensitive consumers, `emit_resolved_identity = True` makes the
@@ -94,9 +93,7 @@ numbered XLS release. Identity-capable bundles validate the implied and explicit
 XLS releases by default; `allow_xls_pin_mismatch = True` is an explicit
 development override. Trusted identity emission requires
 `artifact_source = "download_only"` so the bundle cannot silently reuse
-consumer-owned installed or local artifacts. It also rejects
-`local_xls_aot_runtime_source_path`, because those source bytes are not covered
-by the resolved XLS identity.
+consumer-owned installed or local artifacts.
 
 Identity-capable bundles may use `xlsynth_driver_git_revision = "<40-char SHA>"`
 instead of `xlsynth_driver_version`; the lazy driver action then installs with
@@ -142,18 +139,9 @@ do not use that repo directly or publish it with `use_repo(...)`.
 The runtime repo exposes:
 
 - `@<name>_runtime//:libxls` and `@<name>_runtime//:libxls_link` for native consumers
-- `@<name>_runtime//:xls_aot_runtime`,
-  `@<name>_runtime//:xls_aot_runtime_file`, and
-  `@<name>_runtime//:xls_aot_runtime_link_config_file` when the selected XLS
-  line provides the standalone AOT static runtime archive plus its producer-owned
-  link metadata
-- `@<name>_runtime//:xls_aot_runtime_source_dep` when the selected XLS line
-  provides the source-backed standalone AOT runtime asset, for Bazel final
-  links that declare native runtime ownership instead of importing the
-  flattened archive
 - `@<name>_runtime//:dslx_stdlib` for packages that need the standard library tree
 - `@<name>_runtime//:xlsynth_sys_artifact_config` for the modern single-file
-  build-script contract shared by `xlsynth-sys` and `xlsynth-aot-runtime`
+  `xlsynth-sys` build-script contract
 - `@<name>_runtime//:xlsynth_sys_legacy_stdlib` and
   `@<name>_runtime//:xlsynth_sys_legacy_dso` for frozen `xlsynth-sys` releases that
   still use the paired `DSLX_STDLIB_PATH` / `XLS_DSO_PATH` contract
@@ -169,31 +157,7 @@ The runtime repo exposes:
 `xlsynth_sys_dep`, and, for frozen releases, `xlsynth_sys_legacy_stdlib` plus
 `xlsynth_sys_legacy_dso`, rather than spelling generic bundle internals like
 `artifact_config`, `libxls_file`, `libxls`, or `dslx_stdlib` directly in
-downstream `MODULE.bazel` files. `xlsynth-aot-runtime` consumers should reuse
-the same artifact-config export so their build scripts receive the matching
-standalone runtime archive and its producer-owned link config without a second
-bundle contract. Older bundles may omit the archive pair entirely; that keeps
-non-AOT consumers on old XLS lines valid while making an AOT consumer fail
-locally if it selects a bundle that cannot provide the runtime artifacts it
-needs.
-
-For direct Cargo linking, `xlsynth-aot-runtime` uses its default native mode
-and requests the released `libxls_aot_runtime.a` archive. For Bazel linking,
-pair `@<name>_runtime//:xls_aot_runtime_source_dep` with
-`XLS_AOT_RUNTIME_LINK_MODE = "declared"` in the crate build-script
-environment:
-
-```text
-Bazel target
-  -> depends on @<name>_runtime//:xls_aot_runtime_source_dep
-  -> depends on xlsynth-aot-runtime configured with declared link mode
-
-xlsynth-aot-runtime
-  -> emits no native runtime archive link request
-```
-
-Declared link mode changes only which build graph supplies the native runtime
-symbols; it does not change standalone AOT runtime execution.
+downstream `MODULE.bazel` files.
 
 Supported DSLX rules may opt out of the registered default bundle with
 `xls_bundle = "@<name>_toolchain//:bundle"`. Today that escape hatch is available on

--- a/artifact_resolution_test.py
+++ b/artifact_resolution_test.py
@@ -1025,6 +1025,50 @@ Tag        Type                         Name/Value
             self.assertEqual(metadata["libxls_runtime_files"], "libc++.so.1")
             self.assertTrue((repo_root / "libc++.so.1").is_file())
 
+    def test_stage_runtime_payload_removes_legacy_aot_runtime_paths(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            input_root = repo_root / "_inputs"
+            tools_root = input_root / "tools"
+            stdlib_root = tools_root / "xls" / "dslx" / "stdlib"
+            stdlib_root.mkdir(parents = True)
+            (stdlib_root / "std.x").write_text("// stdlib\n", encoding = "utf-8")
+            for binary in materialize_xls_bundle.TOOL_BINARIES:
+                (tools_root / binary).write_text("", encoding = "utf-8")
+
+            libxls_path = input_root / "libxls.so"
+            libxls_path.write_text("xls\n", encoding = "utf-8")
+            legacy_paths = [
+                repo_root / "libxls_aot_runtime.a",
+                repo_root / "libxls_aot_runtime_link.toml",
+                repo_root / "xls_aot_runtime_source",
+            ]
+            legacy_paths[0].write_text("stale archive\n", encoding = "utf-8")
+            legacy_paths[1].write_text("stale config\n", encoding = "utf-8")
+            legacy_paths[2].mkdir()
+            (legacy_paths[2] / "BUILD.bazel").write_text(
+                'filegroup(name = "stale")\n',
+                encoding = "utf-8",
+            )
+
+            with mock.patch.object(
+                materialize_xls_bundle,
+                "normalize_runtime_library_identity",
+                return_value = [],
+            ):
+                materialize_xls_bundle.stage_runtime_payload(
+                    repo_root,
+                    {
+                        "tools_root": tools_root,
+                        "dslx_stdlib_root": stdlib_root,
+                        "libxls": libxls_path,
+                        "runtime_files": [],
+                    },
+                )
+
+            for legacy_path in legacy_paths:
+                self.assertFalse(legacy_path.exists())
+
     def test_materialize_toolchain_surface_records_driver_capabilities(self):
         with tempfile.TemporaryDirectory() as tempdir:
             repo_root = Path(tempdir)

--- a/artifact_resolution_test.py
+++ b/artifact_resolution_test.py
@@ -4,7 +4,6 @@ import json
 import os
 from pathlib import Path
 import sys
-import tarfile
 import tempfile
 import unittest
 from unittest import mock
@@ -70,9 +69,6 @@ class ArtifactResolutionTest(unittest.TestCase):
                 "/tools/xlsynth/v0.38.0",
                 "/tools/xlsynth/v0.38.0/xls/dslx/stdlib",
                 "/tools/xlsynth/v0.38.0/libxls.dylib" if sys.platform == "darwin" else "/tools/xlsynth/v0.38.0/libxls.so",
-                "/tools/xlsynth/v0.38.0/libxls_aot_runtime.a",
-                "/tools/xlsynth/v0.38.0/libxls_aot_runtime_link.toml",
-                "/tools/xlsynth/v0.38.0/xls-aot-runtime-source.tar.gz",
             ],
         )
 
@@ -109,17 +105,6 @@ class ArtifactResolutionTest(unittest.TestCase):
                 exists_fn = lambda path: False,
             )
 
-    def test_installed_paths_require_static_aot_runtime_pair(self):
-        with self.assertRaisesRegex(ValueError, "together"):
-            materialize_xls_bundle.resolve_artifact_plan(
-                artifact_source = "installed_only",
-                xls_version = "0.38.0",
-                driver_version = "0.33.0",
-                installed_tools_root_prefix = "/tools/xlsynth",
-                installed_driver_root_prefix = "/tools/xlsynth-driver",
-                exists_fn = lambda path: not path.endswith("libxls_aot_runtime_link.toml"),
-            )
-
     def test_download_only_skips_installed_probe(self):
         observed_paths = []
 
@@ -136,19 +121,6 @@ class ArtifactResolutionTest(unittest.TestCase):
         self.assertEqual(plan["mode"], "download")
         self.assertEqual(observed_paths, [])
 
-    def test_download_only_can_use_local_aot_runtime_source(self):
-        plan = materialize_xls_bundle.resolve_artifact_plan(
-            artifact_source = "download_only",
-            xls_version = "0.38.0",
-            driver_version = "0.33.0",
-            local_xls_aot_runtime_source_path = "/tmp/review/xls-aot-runtime-source.tar.gz",
-        )
-        self.assertEqual(plan["mode"], "download")
-        self.assertEqual(
-            plan["xls_aot_runtime_source"],
-            Path("/tmp/review/xls-aot-runtime-source.tar.gz"),
-        )
-
     def test_local_paths_bypass_versioned_selection(self):
         plan = materialize_xls_bundle.resolve_artifact_plan(
             artifact_source = "local_paths",
@@ -158,48 +130,12 @@ class ArtifactResolutionTest(unittest.TestCase):
             local_dslx_stdlib_path = "/tmp/xls-local-dev/stdlib",
             local_driver_path = "/tmp/xls-local-dev/xlsynth-driver",
             local_libxls_path = "/tmp/xls-local-dev/libxls.so",
-            local_xls_aot_runtime_path = "/tmp/xls-local-dev/libxls_aot_runtime.a",
-            local_xls_aot_runtime_link_config_path = "/tmp/xls-local-dev/libxls_aot_runtime_link.toml",
         )
         self.assertEqual(plan["mode"], "local_paths")
         self.assertEqual(
             materialize_xls_bundle.derive_runtime_library_path(plan["libxls"]),
             "/tmp/xls-local-dev",
         )
-        self.assertEqual(
-            plan["xls_aot_runtime"],
-            Path("/tmp/xls-local-dev/libxls_aot_runtime.a"),
-        )
-        self.assertEqual(
-            plan["xls_aot_runtime_link_config"],
-            Path("/tmp/xls-local-dev/libxls_aot_runtime_link.toml"),
-        )
-
-    def test_local_paths_allow_bundle_without_static_aot_runtime(self):
-        plan = materialize_xls_bundle.resolve_artifact_plan(
-            artifact_source = "local_paths",
-            xls_version = "",
-            driver_version = "",
-            local_tools_path = "/tmp/xls-local-dev/tools",
-            local_dslx_stdlib_path = "/tmp/xls-local-dev/stdlib",
-            local_driver_path = "/tmp/xls-local-dev/xlsynth-driver",
-            local_libxls_path = "/tmp/xls-local-dev/libxls.so",
-        )
-        self.assertIsNone(plan["xls_aot_runtime"])
-        self.assertIsNone(plan["xls_aot_runtime_link_config"])
-
-    def test_local_paths_require_static_aot_runtime_pair(self):
-        with self.assertRaisesRegex(ValueError, "together"):
-            materialize_xls_bundle.resolve_artifact_plan(
-                artifact_source = "local_paths",
-                xls_version = "",
-                driver_version = "",
-                local_tools_path = "/tmp/xls-local-dev/tools",
-                local_dslx_stdlib_path = "/tmp/xls-local-dev/stdlib",
-                local_driver_path = "/tmp/xls-local-dev/xlsynth-driver",
-                local_libxls_path = "/tmp/xls-local-dev/libxls.so",
-                local_xls_aot_runtime_path = "/tmp/xls-local-dev/libxls_aot_runtime.a",
-            )
 
     def test_resolve_driver_plan_prefers_installed_driver(self):
         plan = materialize_xls_bundle.resolve_driver_plan(
@@ -364,15 +300,6 @@ printf 'fallback body\\n'
         self.assertEqual(plan["driver"], Path("/eda-tools/xlsynth-driver/0.33.0/bin/xlsynth-driver"))
         expected_name = "libxls.dylib" if sys.platform == "darwin" else "libxls.so"
         self.assertEqual(plan["libxls"].name, expected_name)
-        self.assertEqual(plan["xls_aot_runtime"].name, "libxls_aot_runtime.a")
-        self.assertEqual(
-            plan["xls_aot_runtime_link_config"].name,
-            "libxls_aot_runtime_link.toml",
-        )
-        self.assertEqual(
-            plan["xls_aot_runtime_source"].name,
-            "xls-aot-runtime-source.tar.gz",
-        )
 
     def test_build_driver_environment_sets_runtime_library_search_path(self):
         libxls_path = "/tmp/xls-bundle/libxls.dylib" if sys.platform == "darwin" else "/tmp/xls-bundle/libxls.so"
@@ -685,25 +612,13 @@ printf 'fallback body\\n'
     def test_trusted_resolved_identity_requires_download_only_artifacts(self):
         materialize_xls_bundle.validate_resolved_identity_inputs(
             "download_only",
-            "",
         )
         for artifact_source in ["auto", "installed_only", "local_paths"]:
             with self.subTest(artifact_source = artifact_source):
                 with self.assertRaisesRegex(ValueError, "requires artifact_source=download_only"):
                     materialize_xls_bundle.validate_resolved_identity_inputs(
                         artifact_source,
-                        "",
                     )
-
-    def test_trusted_resolved_identity_rejects_local_aot_runtime_source(self):
-        with self.assertRaisesRegex(
-            ValueError,
-            "cannot use local_xls_aot_runtime_source_path",
-        ):
-            materialize_xls_bundle.validate_resolved_identity_inputs(
-                "download_only",
-                "/tmp/review/xls-aot-runtime-source.tar.gz",
-            )
 
     def test_build_rustup_toolchain_install_command_uses_minimal_profile(self):
         command = materialize_xls_bundle.build_rustup_toolchain_install_command("/usr/bin/rustup")
@@ -751,9 +666,6 @@ printf 'fallback body\\n'
             for binary in materialize_xls_bundle.TOOL_BINARIES:
                 (download_root / binary).write_text("", encoding = "utf-8")
             (download_root / "libxls-v0.38.0-arm64.dylib").write_text("", encoding = "utf-8")
-            (download_root / "libxls_aot_runtime-arm64.a").write_text("", encoding = "utf-8")
-            (download_root / "libxls_aot_runtime_link-arm64.toml").write_text("", encoding = "utf-8")
-            (download_root / "xls-aot-runtime-source.tar.gz").write_text("", encoding = "utf-8")
 
             with mock.patch.object(materialize_xls_bundle, "detect_host_platform", return_value = "arm64"):
                 with mock.patch.object(materialize_xls_bundle.subprocess, "run") as mock_run:
@@ -765,38 +677,7 @@ printf 'fallback body\\n'
                 resolved["libxls"],
                 download_root / "libxls-v0.38.0-arm64.dylib",
             )
-            self.assertEqual(
-                resolved["xls_aot_runtime"],
-                download_root / "libxls_aot_runtime-arm64.a",
-            )
-            self.assertEqual(
-                resolved["xls_aot_runtime_link_config"],
-                download_root / "libxls_aot_runtime_link-arm64.toml",
-            )
-            self.assertEqual(
-                resolved["xls_aot_runtime_source"],
-                download_root / "xls-aot-runtime-source.tar.gz",
-            )
             self.assertEqual(resolved["runtime_files"], [])
-            mock_run.assert_not_called()
-
-    def test_download_versioned_artifacts_reuses_valid_cache_without_aot_runtime(self):
-        with tempfile.TemporaryDirectory() as tempdir:
-            repo_root = Path(tempdir)
-            download_root = repo_root / "_downloaded_xls" / "arm64" / "0.38.0"
-            (download_root / "xls" / "dslx" / "stdlib").mkdir(parents = True)
-            (download_root / "xls" / "dslx" / "stdlib" / "std.x").write_text("// stdlib\n", encoding = "utf-8")
-            for binary in materialize_xls_bundle.TOOL_BINARIES:
-                (download_root / binary).write_text("", encoding = "utf-8")
-            (download_root / "libxls-v0.38.0-arm64.dylib").write_text("", encoding = "utf-8")
-
-            with mock.patch.object(materialize_xls_bundle, "detect_host_platform", return_value = "arm64"):
-                with mock.patch.object(materialize_xls_bundle.subprocess, "run") as mock_run:
-                    resolved = materialize_xls_bundle.download_versioned_artifacts(repo_root, "0.38.0")
-
-            self.assertIsNone(resolved["xls_aot_runtime"])
-            self.assertIsNone(resolved["xls_aot_runtime_link_config"])
-            self.assertIsNone(resolved["xls_aot_runtime_source"])
             mock_run.assert_not_called()
 
     def test_load_runtime_manifest_returns_runtime_files(self):
@@ -1116,19 +997,6 @@ Tag        Type                         Name/Value
 
             libxls_path = input_root / "libxls-v0.38.0.so"
             libxls_path.write_text("xls\n", encoding = "utf-8")
-            xls_aot_runtime_path = input_root / "libxls_aot_runtime.a"
-            xls_aot_runtime_path.write_text("aot\n", encoding = "utf-8")
-            xls_aot_runtime_link_config_path = input_root / "libxls_aot_runtime_link.toml"
-            xls_aot_runtime_link_config_path.write_text("format_version = 1\n", encoding = "utf-8")
-            source_repo_root = input_root / "source_repo"
-            source_repo_root.mkdir()
-            (source_repo_root / "BUILD.bazel").write_text(
-                'alias(name = "standalone_aot_runtime", actual = "//:dummy")\n',
-                encoding = "utf-8",
-            )
-            xls_aot_runtime_source_path = input_root / "xls-aot-runtime-source.tar.gz"
-            with tarfile.open(xls_aot_runtime_source_path, "w:gz") as archive:
-                archive.add(source_repo_root / "BUILD.bazel", arcname = "BUILD.bazel")
             runtime_companion = input_root / "libc++.so.1"
             runtime_companion.write_text("runtime\n", encoding = "utf-8")
 
@@ -1143,9 +1011,6 @@ Tag        Type                         Name/Value
                         "tools_root": tools_root,
                         "dslx_stdlib_root": stdlib_root,
                         "libxls": libxls_path,
-                        "xls_aot_runtime": xls_aot_runtime_path,
-                        "xls_aot_runtime_link_config": xls_aot_runtime_link_config_path,
-                        "xls_aot_runtime_source": xls_aot_runtime_source_path,
                         "runtime_files": [runtime_companion],
                     },
                 )
@@ -1155,26 +1020,9 @@ Tag        Type                         Name/Value
                 for line in (repo_root / "runtime_metadata.txt").read_text(encoding = "utf-8").splitlines()
                 if line
             )
-            artifact_config = (repo_root / "xlsynth_artifact_config.toml").read_text(
-                encoding = "utf-8"
-            )
             self.assertEqual(metadata["libxls_name"], "libxls.so")
-            self.assertEqual(metadata["xls_aot_runtime_name"], "libxls_aot_runtime.a")
-            self.assertEqual(
-                metadata["xls_aot_runtime_link_config_name"],
-                "libxls_aot_runtime_link.toml",
-            )
-            self.assertEqual(metadata["xls_aot_runtime_source_repo"], "xls_aot_runtime_source")
             self.assertEqual(metadata["libxls_runtime_aliases"], "libxls-v0.38.0.so")
             self.assertEqual(metadata["libxls_runtime_files"], "libc++.so.1")
-            self.assertIn('aot_runtime_path = "libxls_aot_runtime.a"', artifact_config)
-            self.assertIn(
-                'aot_runtime_link_config_path = "libxls_aot_runtime_link.toml"',
-                artifact_config,
-            )
-            self.assertTrue((repo_root / "libxls_aot_runtime.a").is_file())
-            self.assertTrue((repo_root / "libxls_aot_runtime_link.toml").is_file())
-            self.assertTrue((repo_root / "xls_aot_runtime_source" / "BUILD.bazel").is_file())
             self.assertTrue((repo_root / "libc++.so.1").is_file())
 
     def test_materialize_toolchain_surface_records_driver_capabilities(self):
@@ -1189,8 +1037,6 @@ Tag        Type                         Name/Value
             driver_path.write_text("", encoding = "utf-8")
             libxls_path = input_root / "libxls.so"
             libxls_path.write_text("xls\n", encoding = "utf-8")
-            xls_aot_runtime_path = input_root / "libxls_aot_runtime.a"
-            xls_aot_runtime_path.write_text("aot\n", encoding = "utf-8")
             runtime_companion = input_root / "libc++.so.1"
             runtime_companion.write_text("runtime\n", encoding = "utf-8")
 
@@ -1202,7 +1048,6 @@ Tag        Type                         Name/Value
                     "driver": driver_path,
                     "dslx_stdlib_root": stdlib_root,
                     "libxls": libxls_path,
-                    "xls_aot_runtime": xls_aot_runtime_path,
                     "runtime_files": [runtime_companion],
                 },
             ):

--- a/download_release.py
+++ b/download_release.py
@@ -56,18 +56,6 @@ def build_dso_release_filename(platform, version_tuple):
     return filename
 
 
-def build_static_aot_runtime_release_filename(platform):
-    return "libxls_aot_runtime-{}.a".format(platform)
-
-
-def build_static_aot_runtime_link_config_release_filename(platform):
-    return "libxls_aot_runtime_link-{}.toml".format(platform)
-
-
-def build_static_aot_runtime_source_release_filename():
-    return "xls-aot-runtime-source.tar.gz"
-
-
 def build_runtime_tarball_release_filename(platform):
     return "libxls-runtime-{}.tar.gz".format(platform)
 
@@ -270,39 +258,6 @@ def main():
 
     for artifact, is_binary in artifacts:
         high_integrity_download(base_url, artifact, options.output_dir, options.max_attempts, is_binary, options.platform)
-
-    if options.dso:
-        static_aot_runtime = build_static_aot_runtime_release_filename(options.platform)
-        static_aot_runtime_link_config = build_static_aot_runtime_link_config_release_filename(
-            options.platform
-        )
-        archive_present = try_high_integrity_download(
-            base_url,
-            static_aot_runtime,
-            options.output_dir,
-            options.max_attempts,
-            is_binary = False,
-        )
-        link_config_present = try_high_integrity_download(
-            base_url,
-            static_aot_runtime_link_config,
-            options.output_dir,
-            options.max_attempts,
-            is_binary = False,
-        )
-        if archive_present != link_config_present:
-            print("Ignoring partial standalone AOT runtime asset set for {}".format(options.platform))
-            for partial_name in [static_aot_runtime, static_aot_runtime_link_config]:
-                partial_path = os.path.join(options.output_dir, partial_name)
-                if os.path.exists(partial_path):
-                    os.remove(partial_path)
-        try_high_integrity_download(
-            base_url,
-            build_static_aot_runtime_source_release_filename(),
-            options.output_dir,
-            options.max_attempts,
-            is_binary = False,
-        )
 
     # Download and extract dslx_stdlib.tar.gz
     stdlib_filename = "dslx_stdlib.tar.gz"

--- a/download_release_test.py
+++ b/download_release_test.py
@@ -72,28 +72,6 @@ class DownloadReleaseTest(unittest.TestCase):
             "libxls-runtime-ubuntu2004-manifest.json",
         )
 
-    def test_static_aot_runtime_release_filename_is_platform_scoped(self):
-        self.assertEqual(
-            download_release.build_static_aot_runtime_release_filename("arm64"),
-            "libxls_aot_runtime-arm64.a",
-        )
-        self.assertEqual(
-            download_release.build_static_aot_runtime_release_filename("ubuntu2004"),
-            "libxls_aot_runtime-ubuntu2004.a",
-        )
-        self.assertEqual(
-            download_release.build_static_aot_runtime_link_config_release_filename("arm64"),
-            "libxls_aot_runtime_link-arm64.toml",
-        )
-        self.assertEqual(
-            download_release.build_static_aot_runtime_link_config_release_filename("ubuntu2004"),
-            "libxls_aot_runtime_link-ubuntu2004.toml",
-        )
-        self.assertEqual(
-            download_release.build_static_aot_runtime_source_release_filename(),
-            "xls-aot-runtime-source.tar.gz",
-        )
-
     def test_copy_url_to_path_retries_after_stream_reset(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             destination_path = f"{temp_dir}/artifact"

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -105,51 +105,17 @@ def _toolchain_driver_supports_sv_struct_field_ordering(
 
 def _runtime_build_file(
         libxls_name,
-        xls_aot_runtime_name,
-        xls_aot_runtime_link_config_name,
-        xls_aot_runtime_source_repo,
         runtime_files,
         runtime_aliases,
         resolved_identity,
         toolchain_repo_name):
     tool_list = ",\n        ".join(['"{}"'.format(name) for name in _TOOL_BINARIES])
-    exported_names = _TOOL_BINARIES + [libxls_name] + runtime_files + runtime_aliases
-    if xls_aot_runtime_name:
-        exported_names.append(xls_aot_runtime_name)
-        exported_names.append(xls_aot_runtime_link_config_name)
-    exported_files = ",\n    ".join(['"{}"'.format(name) for name in exported_names])
+    exported_files = ",\n    ".join(
+        ['"{}"'.format(name) for name in _TOOL_BINARIES + [libxls_name] + runtime_files + runtime_aliases],
+    )
     runtime_file_srcs = ",\n        ".join(['"{}"'.format(name) for name in runtime_files])
     runtime_alias_srcs = ",\n        ".join(['"{}"'.format(name) for name in runtime_aliases])
     lib_target = libxls_name
-    aot_runtime_rule = """
-filegroup(
-    name = "xls_aot_runtime_file",
-    srcs = ["{xls_aot_runtime_name}"],
-    visibility = ["//visibility:public"],
-)
-filegroup(
-    name = "xls_aot_runtime_link_config_file",
-    srcs = ["{xls_aot_runtime_link_config_name}"],
-    visibility = ["//visibility:public"],
-)
-cc_import(
-    name = "xls_aot_runtime",
-    static_library = ":xls_aot_runtime_file",
-    visibility = ["//visibility:public"],
-)
-""".format(
-        xls_aot_runtime_name = xls_aot_runtime_name,
-        xls_aot_runtime_link_config_name = xls_aot_runtime_link_config_name,
-    ) if xls_aot_runtime_name else ""
-    aot_runtime_source_rule = """
-alias(
-    name = "xls_aot_runtime_source_dep",
-    actual = "//{xls_aot_runtime_source_repo}:standalone_aot_runtime",
-    visibility = ["//visibility:public"],
-)
-""".format(
-        xls_aot_runtime_source_repo = xls_aot_runtime_source_repo,
-    ) if xls_aot_runtime_source_repo else ""
     resolved_identity_rule = """
 filegroup(
     name = "resolved_identity_for_toolchain",
@@ -210,8 +176,6 @@ copy_flat_files_to_directory(
 )
 
 {lib_file_rule}
-{aot_runtime_rule}
-{aot_runtime_source_rule}
 {resolved_identity_rule}
 
 xlsynth_artifact_config(
@@ -219,8 +183,6 @@ xlsynth_artifact_config(
     dso_name = "{libxls_name}",
     dslx_stdlib = ":dslx_stdlib",
     shared_library = ":libxls_file",
-    static_aot_runtime = {static_aot_runtime},
-    static_aot_runtime_link_config = {static_aot_runtime_link_config},
     visibility = ["//visibility:public"],
 )
 
@@ -268,7 +230,6 @@ xls_runtime_surface(
     name = "runtime",
     dslx_stdlib = ":dslx_stdlib",
     libxls = ":libxls_file",
-    xls_aot_runtime = {static_aot_runtime},
     runtime_files = [":libxls_runtime_files"],
     tools_root = ":tools_root_files",
     visibility = ["//visibility:public"],
@@ -278,11 +239,7 @@ xls_runtime_surface(
         tool_list = tool_list,
         libxls_name = libxls_name,
         lib_file_rule = lib_file_rule.strip(),
-        aot_runtime_rule = aot_runtime_rule.strip(),
-        aot_runtime_source_rule = aot_runtime_source_rule.strip(),
         resolved_identity_rule = resolved_identity_rule.strip(),
-        static_aot_runtime = '":xls_aot_runtime_file"' if xls_aot_runtime_name else "None",
-        static_aot_runtime_link_config = '":xls_aot_runtime_link_config_file"' if xls_aot_runtime_name else "None",
     )
 
 def _string_attr_line(name, value):
@@ -475,18 +432,6 @@ def _materialize_bundle_args(repo_ctx, surface):
         args.extend(["--local-driver-path", repo_ctx.attr.local_driver_path])
     if repo_ctx.attr.local_libxls_path:
         args.extend(["--local-libxls-path", repo_ctx.attr.local_libxls_path])
-    if repo_ctx.attr.local_xls_aot_runtime_path:
-        args.extend(["--local-xls-aot-runtime-path", repo_ctx.attr.local_xls_aot_runtime_path])
-    if repo_ctx.attr.local_xls_aot_runtime_link_config_path:
-        args.extend([
-            "--local-xls-aot-runtime-link-config-path",
-            repo_ctx.attr.local_xls_aot_runtime_link_config_path,
-        ])
-    if repo_ctx.attr.local_xls_aot_runtime_source_path:
-        args.extend([
-            "--local-xls-aot-runtime-source-path",
-            repo_ctx.attr.local_xls_aot_runtime_source_path,
-        ])
     return args
 
 def _runtime_repo_impl(repo_ctx):
@@ -515,9 +460,6 @@ def _runtime_repo_impl(repo_ctx):
         "BUILD.bazel",
         _runtime_build_file(
             libxls_name = metadata["libxls_name"],
-            xls_aot_runtime_name = metadata["xls_aot_runtime_name"],
-            xls_aot_runtime_link_config_name = metadata["xls_aot_runtime_link_config_name"],
-            xls_aot_runtime_source_repo = metadata["xls_aot_runtime_source_repo"],
             runtime_files = runtime_files,
             runtime_aliases = runtime_aliases,
             resolved_identity = repo_ctx.path("resolved_identity.json").exists,
@@ -566,9 +508,6 @@ _runtime_repo_attrs = {
     "local_driver_path": attr.string(),
     "local_dslx_stdlib_path": attr.string(),
     "local_libxls_path": attr.string(),
-    "local_xls_aot_runtime_path": attr.string(),
-    "local_xls_aot_runtime_link_config_path": attr.string(),
-    "local_xls_aot_runtime_source_path": attr.string(),
     "local_tools_path": attr.string(),
     "toolchain_repo_name": attr.string(mandatory = True),
     "xls_version": attr.string(),
@@ -588,9 +527,6 @@ _toolchain_repo_attrs = {
     "local_driver_path": attr.string(),
     "local_dslx_stdlib_path": attr.string(),
     "local_libxls_path": attr.string(),
-    "local_xls_aot_runtime_path": attr.string(),
-    "local_xls_aot_runtime_link_config_path": attr.string(),
-    "local_xls_aot_runtime_source_path": attr.string(),
     "local_tools_path": attr.string(),
     "repo_alias": attr.string(mandatory = True),
     "runtime_repo_name": attr.string(mandatory = True),
@@ -638,9 +574,6 @@ _toolchain_tag = tag_class(attrs = {
     "local_driver_path": attr.string(),
     "local_dslx_stdlib_path": attr.string(),
     "local_libxls_path": attr.string(),
-    "local_xls_aot_runtime_path": attr.string(),
-    "local_xls_aot_runtime_link_config_path": attr.string(),
-    "local_xls_aot_runtime_source_path": attr.string(),
     "local_tools_path": attr.string(),
     "name": attr.string(mandatory = True),
     "xls_version": attr.string(),
@@ -665,9 +598,6 @@ def _xls_extension_impl(module_ctx):
                 local_driver_path = toolchain.local_driver_path,
                 local_dslx_stdlib_path = toolchain.local_dslx_stdlib_path,
                 local_libxls_path = toolchain.local_libxls_path,
-                local_xls_aot_runtime_path = toolchain.local_xls_aot_runtime_path,
-                local_xls_aot_runtime_link_config_path = toolchain.local_xls_aot_runtime_link_config_path,
-                local_xls_aot_runtime_source_path = toolchain.local_xls_aot_runtime_source_path,
                 local_tools_path = toolchain.local_tools_path,
                 toolchain_repo_name = toolchain_name,
                 xls_version = toolchain.xls_version,
@@ -693,9 +623,6 @@ def _xls_extension_impl(module_ctx):
                 local_driver_path = toolchain.local_driver_path,
                 local_dslx_stdlib_path = toolchain.local_dslx_stdlib_path,
                 local_libxls_path = toolchain.local_libxls_path,
-                local_xls_aot_runtime_path = toolchain.local_xls_aot_runtime_path,
-                local_xls_aot_runtime_link_config_path = toolchain.local_xls_aot_runtime_link_config_path,
-                local_xls_aot_runtime_source_path = toolchain.local_xls_aot_runtime_source_path,
                 local_tools_path = toolchain.local_tools_path,
                 repo_alias = toolchain_name,
                 runtime_repo_name = runtime_name,

--- a/external_bundle_exports_test.py
+++ b/external_bundle_exports_test.py
@@ -82,7 +82,6 @@ class ExternalBundleExportsTest(unittest.TestCase):
         expected_dso_name = expected_libxls_name()
         self.assertEqual(config_lines["dso_path"].strip('"'), expected_dso_name)
         self.assertEqual(config_lines["dslx_stdlib_path"].strip('"'), "dslx_stdlib")
-        self.assertNotIn("aot_runtime_path", config_lines)
         self.assertTrue((config_path.parent / expected_dso_name).is_file())
         self.assertTrue((config_path.parent / "dslx_stdlib").is_dir())
 

--- a/materialize_xls_bundle.py
+++ b/materialize_xls_bundle.py
@@ -1142,6 +1142,13 @@ def write_toolchain_metadata(repo_root, driver_capabilities):
 
 
 def stage_runtime_payload(repo_root, resolved):
+    for legacy_path in [
+        repo_root / "libxls_aot_runtime.a",
+        repo_root / "libxls_aot_runtime_link.toml",
+        repo_root / "xls_aot_runtime_source",
+    ]:
+        ensure_clean_path(legacy_path)
+
     link_tool_binaries(resolved["tools_root"], repo_root)
     link_stdlib_sources(resolved["dslx_stdlib_root"], repo_root)
 

--- a/materialize_xls_bundle.py
+++ b/materialize_xls_bundle.py
@@ -255,19 +255,11 @@ def write_resolved_identity(repo_root, identity):
     )
 
 
-def validate_resolved_identity_inputs(
-    artifact_source,
-    local_xls_aot_runtime_source_path,
-):
+def validate_resolved_identity_inputs(artifact_source):
     if artifact_source != "download_only":
         raise ValueError(
             "trusted resolved identity requires artifact_source=download_only; "
             "{} may reuse consumer-owned artifacts".format(artifact_source)
-        )
-    elif local_xls_aot_runtime_source_path:
-        raise ValueError(
-            "trusted resolved identity cannot use local_xls_aot_runtime_source_path; "
-            "the local source is not covered by the resolved XLS identity"
         )
 
 
@@ -278,18 +270,6 @@ def libxls_name_for_platform(sys_platform):
         return "libxls.so"
     else:
         raise RuntimeError("Unsupported host platform: {}".format(sys_platform))
-
-
-def static_aot_runtime_name():
-    return "libxls_aot_runtime.a"
-
-
-def static_aot_runtime_link_config_name():
-    return "libxls_aot_runtime_link.toml"
-
-
-def static_aot_runtime_source_name():
-    return "xls-aot-runtime-source.tar.gz"
 
 
 def derive_installed_paths(
@@ -306,9 +286,6 @@ def derive_installed_paths(
         "dslx_stdlib_root": tools_root / "xls" / "dslx" / "stdlib",
         "driver": Path(installed_driver_root_prefix) / normalized_driver_version / "bin" / "xlsynth-driver",
         "libxls": tools_root / libxls_name_for_platform(sys_platform),
-        "xls_aot_runtime": tools_root / static_aot_runtime_name(),
-        "xls_aot_runtime_link_config": tools_root / static_aot_runtime_link_config_name(),
-        "xls_aot_runtime_source": tools_root / static_aot_runtime_source_name(),
     }
 
 
@@ -322,9 +299,6 @@ def derive_installed_runtime_paths(
         "tools_root": tools_root,
         "dslx_stdlib_root": tools_root / "xls" / "dslx" / "stdlib",
         "libxls": tools_root / libxls_name_for_platform(sys_platform),
-        "xls_aot_runtime": tools_root / static_aot_runtime_name(),
-        "xls_aot_runtime_link_config": tools_root / static_aot_runtime_link_config_name(),
-        "xls_aot_runtime_source": tools_root / static_aot_runtime_source_name(),
     }
 
 
@@ -350,9 +324,6 @@ def resolve_artifact_plan(
     local_dslx_stdlib_path = "",
     local_driver_path = "",
     local_libxls_path = "",
-    local_xls_aot_runtime_path = "",
-    local_xls_aot_runtime_link_config_path = "",
-    local_xls_aot_runtime_source_path = "",
     exists_fn = os.path.exists,
 ):
     if surface not in ("runtime", "toolchain"):
@@ -375,27 +346,11 @@ def resolve_artifact_plan(
         missing = [name for name, value in required.items() if not value]
         if missing:
             raise ValueError("local_paths requires {}".format(", ".join(sorted(missing))))
-        if bool(local_xls_aot_runtime_path) != bool(local_xls_aot_runtime_link_config_path):
-            raise ValueError(
-                "local_paths requires local_xls_aot_runtime_path and "
-                "local_xls_aot_runtime_link_config_path together"
-            )
         plan = {
             "mode": "local_paths",
             "tools_root": Path(local_tools_path),
             "dslx_stdlib_root": Path(local_dslx_stdlib_path),
             "libxls": Path(local_libxls_path),
-            "xls_aot_runtime": Path(local_xls_aot_runtime_path) if local_xls_aot_runtime_path else None,
-            "xls_aot_runtime_link_config": (
-                Path(local_xls_aot_runtime_link_config_path)
-                if local_xls_aot_runtime_link_config_path
-                else None
-            ),
-            "xls_aot_runtime_source": (
-                Path(local_xls_aot_runtime_source_path)
-                if local_xls_aot_runtime_source_path
-                else None
-            ),
         }
         if include_driver:
             plan["driver"] = Path(local_driver_path)
@@ -407,14 +362,7 @@ def resolve_artifact_plan(
         raise ValueError("{} requires xls_version".format(artifact_source))
     if include_driver and not driver_identity:
         raise ValueError("{} toolchain surface requires an xlsynth driver release or Git pin".format(artifact_source))
-    if (
-        local_tools_path
-        or local_dslx_stdlib_path
-        or local_driver_path
-        or local_libxls_path
-        or local_xls_aot_runtime_path
-        or local_xls_aot_runtime_link_config_path
-    ):
+    if local_tools_path or local_dslx_stdlib_path or local_driver_path or local_libxls_path:
         raise ValueError("{} does not accept local_paths attrs".format(artifact_source))
     if artifact_source == "download_only":
         if installed_tools_root_prefix or installed_driver_root_prefix:
@@ -445,64 +393,25 @@ def resolve_artifact_plan(
             "mode": "download",
             "xls_version": normalize_version(xls_version),
         }
-        if local_xls_aot_runtime_source_path:
-            plan["xls_aot_runtime_source"] = Path(local_xls_aot_runtime_source_path)
         if include_driver:
             plan["driver_version"] = normalize_version(driver_version)
             if driver_git_revision:
                 plan["driver_git_revision"] = normalize_git_revision(driver_git_revision)
         return plan
 
-    installed_paths_present = all(
-        exists_fn(str(path))
-        for name, path in installed_paths.items()
-        if name not in (
-            "xls_aot_runtime",
-            "xls_aot_runtime_link_config",
-            "xls_aot_runtime_source",
-        )
-    )
-    installed_aot_runtime_present = exists_fn(str(installed_paths["xls_aot_runtime"]))
-    installed_aot_runtime_link_config_present = exists_fn(
-        str(installed_paths["xls_aot_runtime_link_config"])
-    )
-    installed_aot_runtime_source_present = exists_fn(
-        str(installed_paths["xls_aot_runtime_source"])
-    )
-    if installed_aot_runtime_present != installed_aot_runtime_link_config_present:
-        raise ValueError(
-            "installed paths require libxls_aot_runtime.a and "
-            "libxls_aot_runtime_link.toml together"
-        )
+    installed_paths_present = all(exists_fn(str(path)) for path in installed_paths.values())
     if artifact_source == "auto" and installed_paths_present:
         plan = {
             "mode": "installed",
             "tools_root": installed_paths["tools_root"],
             "dslx_stdlib_root": installed_paths["dslx_stdlib_root"],
             "libxls": installed_paths["libxls"],
-            "xls_aot_runtime": (
-                installed_paths["xls_aot_runtime"]
-                if installed_aot_runtime_present
-                else None
-            ),
-            "xls_aot_runtime_link_config": (
-                installed_paths["xls_aot_runtime_link_config"]
-                if installed_aot_runtime_link_config_present
-                else None
-            ),
-            "xls_aot_runtime_source": (
-                installed_paths["xls_aot_runtime_source"]
-                if installed_aot_runtime_source_present
-                else None
-            ),
         }
         if include_driver:
             plan["driver"] = installed_paths["driver"]
             plan["driver_version"] = normalize_version(driver_version)
             if driver_git_revision:
                 plan["driver_git_revision"] = normalize_git_revision(driver_git_revision)
-        if local_xls_aot_runtime_source_path:
-            plan["xls_aot_runtime_source"] = Path(local_xls_aot_runtime_source_path)
         return plan
     if artifact_source == "installed_only":
         if not installed_paths_present:
@@ -517,36 +426,17 @@ def resolve_artifact_plan(
             "tools_root": installed_paths["tools_root"],
             "dslx_stdlib_root": installed_paths["dslx_stdlib_root"],
             "libxls": installed_paths["libxls"],
-            "xls_aot_runtime": (
-                installed_paths["xls_aot_runtime"]
-                if installed_aot_runtime_present
-                else None
-            ),
-            "xls_aot_runtime_link_config": (
-                installed_paths["xls_aot_runtime_link_config"]
-                if installed_aot_runtime_link_config_present
-                else None
-            ),
-            "xls_aot_runtime_source": (
-                installed_paths["xls_aot_runtime_source"]
-                if installed_aot_runtime_source_present
-                else None
-            ),
         }
         if include_driver:
             plan["driver"] = installed_paths["driver"]
             plan["driver_version"] = normalize_version(driver_version)
             if driver_git_revision:
                 plan["driver_git_revision"] = normalize_git_revision(driver_git_revision)
-        if local_xls_aot_runtime_source_path:
-            plan["xls_aot_runtime_source"] = Path(local_xls_aot_runtime_source_path)
         return plan
     plan = {
         "mode": "download",
         "xls_version": normalize_version(xls_version),
     }
-    if local_xls_aot_runtime_source_path:
-        plan["xls_aot_runtime_source"] = Path(local_xls_aot_runtime_source_path)
     if include_driver:
         plan["driver_version"] = normalize_version(driver_version)
         if driver_git_revision:
@@ -1171,46 +1061,10 @@ def resolve_downloaded_artifacts(download_root):
     libxls_candidates = sorted(download_root.glob("libxls-*.so")) + sorted(download_root.glob("libxls-*.dylib"))
     if len(libxls_candidates) != 1:
         raise RuntimeError("Expected exactly one libxls artifact in {}, found {}".format(download_root, libxls_candidates))
-    static_aot_runtime_candidates = sorted(download_root.glob("libxls_aot_runtime-*.a"))
-    if len(static_aot_runtime_candidates) > 1:
-        raise RuntimeError(
-            "Expected at most one libxls_aot_runtime artifact in {}, found {}".format(
-                download_root,
-                static_aot_runtime_candidates,
-            )
-        )
-    static_aot_runtime_link_config_candidates = sorted(
-        download_root.glob("libxls_aot_runtime_link-*.toml")
-    )
-    if len(static_aot_runtime_link_config_candidates) > 1:
-        raise RuntimeError(
-            "Expected at most one libxls_aot_runtime link config artifact in {}, found {}".format(
-                download_root,
-                static_aot_runtime_link_config_candidates,
-            )
-        )
-    if bool(static_aot_runtime_candidates) != bool(static_aot_runtime_link_config_candidates):
-        raise RuntimeError(
-            "Expected libxls_aot_runtime archive and link config together in {}".format(
-                download_root
-            )
-        )
-    static_aot_runtime_source = download_root / static_aot_runtime_source_name()
     return {
         "tools_root": download_root,
         "dslx_stdlib_root": stdlib_root,
         "libxls": libxls_candidates[0],
-        "xls_aot_runtime": static_aot_runtime_candidates[0] if static_aot_runtime_candidates else None,
-        "xls_aot_runtime_link_config": (
-            static_aot_runtime_link_config_candidates[0]
-            if static_aot_runtime_link_config_candidates
-            else None
-        ),
-        "xls_aot_runtime_source": (
-            static_aot_runtime_source
-            if static_aot_runtime_source.exists()
-            else None
-        ),
         "runtime_files": load_runtime_manifest(download_root),
     }
 
@@ -1243,63 +1097,29 @@ def download_versioned_artifacts(repo_root, xls_version):
 
 def resolve_materialization_inputs(repo_root, plan):
     if plan["mode"] == "download":
-        resolved = download_versioned_artifacts(repo_root, plan["xls_version"])
-        if plan.get("xls_aot_runtime_source") is not None:
-            resolved["xls_aot_runtime_source"] = plan["xls_aot_runtime_source"]
-        return resolved
+        return download_versioned_artifacts(repo_root, plan["xls_version"])
     resolved = dict(plan)
     validate_stdlib_root(resolved["dslx_stdlib_root"])
     resolved["runtime_files"] = load_runtime_manifest(Path(resolved["libxls"]).parent)
     return resolved
 
 
-def write_artifact_config(
-        repo_root,
-        libxls_dest,
-        xls_aot_runtime_dest,
-        xls_aot_runtime_link_config_dest,
-):
+def write_artifact_config(repo_root, libxls_dest):
     artifact_config_path = repo_root / "xlsynth_artifact_config.toml"
-    config_lines = [
-        "dso_path = \"{}\"\n".format(libxls_dest.name),
-        "dslx_stdlib_path = \".\"\n",
-    ]
-    if xls_aot_runtime_dest is not None:
-        config_lines.append("aot_runtime_path = \"{}\"\n".format(xls_aot_runtime_dest.name))
-        config_lines.append(
-            "aot_runtime_link_config_path = \"{}\"\n".format(
-                xls_aot_runtime_link_config_dest.name
-            )
-        )
-    artifact_config_path.write_text("".join(config_lines), encoding = "utf-8")
+    artifact_config_path.write_text(
+        "".join([
+            "dso_path = \"{}\"\n".format(libxls_dest.name),
+            "dslx_stdlib_path = \".\"\n",
+        ]),
+        encoding = "utf-8",
+    )
 
 
-def write_runtime_metadata(
-        repo_root,
-        libxls_dest,
-        xls_aot_runtime_dest,
-        xls_aot_runtime_link_config_dest,
-        xls_aot_runtime_source_repo,
-        runtime_aliases,
-        runtime_files,
-):
+def write_runtime_metadata(repo_root, libxls_dest, runtime_aliases, runtime_files):
     metadata_path = repo_root / "runtime_metadata.txt"
     metadata_path.write_text(
         "".join([
             "libxls_name={}\n".format(libxls_dest.name),
-            "xls_aot_runtime_name={}\n".format(
-                xls_aot_runtime_dest.name if xls_aot_runtime_dest is not None else "",
-            ),
-            "xls_aot_runtime_link_config_name={}\n".format(
-                xls_aot_runtime_link_config_dest.name
-                if xls_aot_runtime_link_config_dest is not None
-                else "",
-            ),
-            "xls_aot_runtime_source_repo={}\n".format(
-                xls_aot_runtime_source_repo.name
-                if xls_aot_runtime_source_repo is not None
-                else "",
-            ),
             "libxls_runtime_aliases={}\n".format(",".join(runtime_aliases)),
             "libxls_runtime_files={}\n".format(",".join(sorted(runtime_files))),
         ]),
@@ -1327,30 +1147,6 @@ def stage_runtime_payload(repo_root, resolved):
 
     libxls_dest = repo_root / normalized_libxls_name(resolved["libxls"])
     copy_path(resolved["libxls"], libxls_dest)
-    xls_aot_runtime_dest = None
-    xls_aot_runtime_link_config_dest = None
-    if resolved.get("xls_aot_runtime") is not None:
-        xls_aot_runtime_dest = repo_root / static_aot_runtime_name()
-        copy_path(resolved["xls_aot_runtime"], xls_aot_runtime_dest)
-        xls_aot_runtime_link_config_dest = repo_root / static_aot_runtime_link_config_name()
-        copy_path(
-            resolved["xls_aot_runtime_link_config"],
-            xls_aot_runtime_link_config_dest,
-        )
-    xls_aot_runtime_source_repo = None
-    if resolved.get("xls_aot_runtime_source") is not None:
-        xls_aot_runtime_source_repo = repo_root / "xls_aot_runtime_source"
-        ensure_clean_path(xls_aot_runtime_source_repo)
-        shutil.unpack_archive(
-            str(resolved["xls_aot_runtime_source"]),
-            str(xls_aot_runtime_source_repo),
-        )
-        if not (xls_aot_runtime_source_repo / "BUILD.bazel").is_file():
-            raise ValueError(
-                "Standalone AOT runtime source archive must unpack BUILD.bazel at {}".format(
-                    xls_aot_runtime_source_repo,
-                )
-            )
 
     staged_runtime_files = []
     for runtime_file in resolved.get("runtime_files", []):
@@ -1360,26 +1156,10 @@ def stage_runtime_payload(repo_root, resolved):
             staged_runtime_files.append(runtime_dest.name)
 
     runtime_aliases = normalize_runtime_library_identity(libxls_dest)
-    write_artifact_config(
-        repo_root,
-        libxls_dest,
-        xls_aot_runtime_dest,
-        xls_aot_runtime_link_config_dest,
-    )
-    write_runtime_metadata(
-        repo_root,
-        libxls_dest,
-        xls_aot_runtime_dest,
-        xls_aot_runtime_link_config_dest,
-        xls_aot_runtime_source_repo,
-        runtime_aliases,
-        staged_runtime_files,
-    )
+    write_artifact_config(repo_root, libxls_dest)
+    write_runtime_metadata(repo_root, libxls_dest, runtime_aliases, staged_runtime_files)
     return {
         "libxls_dest": libxls_dest,
-        "xls_aot_runtime_dest": xls_aot_runtime_dest,
-        "xls_aot_runtime_link_config_dest": xls_aot_runtime_link_config_dest,
-        "xls_aot_runtime_source_repo": xls_aot_runtime_source_repo,
         "runtime_aliases": runtime_aliases,
         "runtime_files": staged_runtime_files,
     }
@@ -1660,9 +1440,6 @@ def parse_args(argv):
     parser.add_argument("--driver-resolved-identity-input", default = "")
     parser.add_argument("--driver-resolved-identity-output", default = "")
     parser.add_argument("--rustup-path", default = "")
-    parser.add_argument("--local-xls-aot-runtime-path", default = "")
-    parser.add_argument("--local-xls-aot-runtime-link-config-path", default = "")
-    parser.add_argument("--local-xls-aot-runtime-source-path", default = "")
     return parser.parse_args(argv)
 
 
@@ -1706,10 +1483,7 @@ def main(argv):
     if args.xls_version and args.xls_git_revision:
         raise ValueError("XLS materialization accepts either a release tag or Git revision, not both")
     if args.emit_resolved_identity:
-        validate_resolved_identity_inputs(
-            args.artifact_source,
-            args.local_xls_aot_runtime_source_path,
-        )
+        validate_resolved_identity_inputs(args.artifact_source)
         resolved_identity = resolve_archive_identity(
             xls_version = args.xls_version,
             xls_git_revision = args.xls_git_revision,
@@ -1734,9 +1508,6 @@ def main(argv):
         local_dslx_stdlib_path = args.local_dslx_stdlib_path,
         local_driver_path = args.local_driver_path,
         local_libxls_path = args.local_libxls_path,
-        local_xls_aot_runtime_path = args.local_xls_aot_runtime_path,
-        local_xls_aot_runtime_link_config_path = args.local_xls_aot_runtime_link_config_path,
-        local_xls_aot_runtime_source_path = args.local_xls_aot_runtime_source_path,
     )
     if args.xlsynth_driver_git_revision:
         if args.artifact_source == "local_paths":

--- a/trusted_identity_boundary_test.bzl
+++ b/trusted_identity_boundary_test.bzl
@@ -15,7 +15,6 @@ def _fake_runtime_impl(ctx):
             runtime_library_path = artifact.dirname,
             tools_root = artifact,
             tools_path = artifact.dirname,
-            xls_aot_runtime = None,
         ),
         DefaultInfo(files = depset([artifact])),
     ]

--- a/xls_toolchain.bzl
+++ b/xls_toolchain.bzl
@@ -22,7 +22,6 @@ XlsArtifactBundleInfo = provider(
         "resolved_identity": "Machine-readable resolved producer identity manifest, when requested.",
         "tools_root": "The XLS tool root tree artifact.",
         "tools_path": "Directory path containing the XLS tool binaries.",
-        "xls_aot_runtime": "The standalone AOT static runtime archive.",
     },
 )
 
@@ -46,7 +45,6 @@ XlsRuntimeSurfaceInfo = provider(
         "runtime_library_path": "Directory containing libxls for runtime loading.",
         "tools_root": "One XLS tool artifact from the selected tools root.",
         "tools_path": "Directory path containing the XLS tool binaries.",
-        "xls_aot_runtime": "The standalone AOT static runtime archive.",
     },
 )
 
@@ -104,7 +102,6 @@ def _bundle_struct_from_provider(bundle):
         resolved_identity = bundle.resolved_identity,
         tools_root = bundle.tools_root,
         tools_path = bundle.tools_path,
-        xls_aot_runtime = bundle.xls_aot_runtime,
     )
 
 def _runtime_struct_from_provider(runtime):
@@ -117,7 +114,6 @@ def _runtime_struct_from_provider(runtime):
         runtime_library_path = runtime.runtime_library_path,
         tools_root = runtime.tools_root,
         tools_path = runtime.tools_path,
-        xls_aot_runtime = runtime.xls_aot_runtime,
     )
 
 def _toolchain_with_semantics(artifact_selection, ctx):
@@ -181,10 +177,8 @@ def _xls_runtime_surface_impl(ctx):
     tool_files = ctx.attr.tools_root[DefaultInfo].files.to_list()
     dslx_stdlib = _single_directory_artifact(ctx.attr.dslx_stdlib, "dslx_stdlib")
     libxls = _single_artifact(ctx.attr.libxls, "libxls")
-    xls_aot_runtime = _single_artifact(ctx.attr.xls_aot_runtime, "xls_aot_runtime") if ctx.attr.xls_aot_runtime else None
     runtime_files = _dedupe_artifacts(ctx.files.runtime_files)
-    optional_aot_runtime = [xls_aot_runtime] if xls_aot_runtime else []
-    artifact_inputs = _dedupe_artifacts(tool_files + [dslx_stdlib] + optional_aot_runtime + runtime_files)
+    artifact_inputs = _dedupe_artifacts(tool_files + [dslx_stdlib] + runtime_files)
     tools_path = _artifact_directory(tool_files, "tools_root")
     return [
         XlsRuntimeSurfaceInfo(
@@ -196,7 +190,6 @@ def _xls_runtime_surface_impl(ctx):
             runtime_library_path = libxls.dirname,
             tools_root = tool_files[0],
             tools_path = tools_path,
-            xls_aot_runtime = xls_aot_runtime,
         ),
         DefaultInfo(files = depset(direct = artifact_inputs)),
     ]
@@ -208,7 +201,6 @@ xls_runtime_surface = rule(
         "libxls": attr.label(allow_files = True, mandatory = True),
         "runtime_files": attr.label_list(allow_files = True),
         "tools_root": attr.label(mandatory = True),
-        "xls_aot_runtime": attr.label(allow_files = True),
     },
 )
 
@@ -438,7 +430,6 @@ def _xls_bundle_impl(ctx):
             resolved_identity = resolved_identity,
             tools_root = runtime.tools_root,
             tools_path = runtime.tools_path,
-            xls_aot_runtime = runtime.xls_aot_runtime,
         ),
         DefaultInfo(files = depset(direct = artifact_inputs)),
     ]
@@ -691,37 +682,12 @@ def _xlsynth_artifact_config_impl(ctx):
     bundle_root = ctx.label.name
     config_output = ctx.actions.declare_file("{}/xlsynth_artifact_config.toml".format(bundle_root))
     dso_output = ctx.actions.declare_file("{}/{}".format(bundle_root, ctx.attr.dso_name))
-    aot_runtime_output = None
-    aot_runtime_link_config_output = None
-    if ctx.file.static_aot_runtime:
-        if not ctx.file.static_aot_runtime_link_config:
-            fail("static_aot_runtime_link_config is required with static_aot_runtime")
-        aot_runtime_output = ctx.actions.declare_file(
-            "{}/{}".format(bundle_root, ctx.file.static_aot_runtime.basename),
-        )
-        aot_runtime_link_config_output = ctx.actions.declare_file(
-            "{}/{}".format(bundle_root, ctx.file.static_aot_runtime_link_config.basename),
-        )
-    elif ctx.file.static_aot_runtime_link_config:
-        fail("static_aot_runtime is required with static_aot_runtime_link_config")
     stdlib_output = ctx.actions.declare_directory("{}/dslx_stdlib".format(bundle_root))
     dslx_stdlib = _single_directory_artifact(ctx.attr.dslx_stdlib, "dslx_stdlib")
     shared_library = ctx.file.shared_library
-    static_aot_runtime = ctx.file.static_aot_runtime
-    static_aot_runtime_link_config = ctx.file.static_aot_runtime_link_config
-    optional_inputs = [static_aot_runtime, static_aot_runtime_link_config] if static_aot_runtime else []
-    optional_outputs = [aot_runtime_output, aot_runtime_link_config_output] if aot_runtime_output else []
-    optional_arguments = [
-        static_aot_runtime.path,
-        aot_runtime_output.path,
-        static_aot_runtime.basename,
-        static_aot_runtime_link_config.path,
-        aot_runtime_link_config_output.path,
-        static_aot_runtime_link_config.basename,
-    ] if static_aot_runtime else ["", "", "", "", "", ""]
     ctx.actions.run_shell(
-        inputs = [dslx_stdlib, shared_library] + optional_inputs,
-        outputs = [config_output, dso_output, stdlib_output] + optional_outputs,
+        inputs = [dslx_stdlib, shared_library],
+        outputs = [config_output, dso_output, stdlib_output],
         arguments = [
             shared_library.path,
             dso_output.path,
@@ -729,7 +695,7 @@ def _xlsynth_artifact_config_impl(ctx):
             stdlib_output.path,
             config_output.path,
             ctx.attr.dso_name,
-        ] + optional_arguments,
+        ],
         command = """
             set -euo pipefail
             shared_library="$1"
@@ -738,28 +704,16 @@ def _xlsynth_artifact_config_impl(ctx):
             stdlib_output="$4"
             config_output="$5"
             dso_name="$6"
-            static_aot_runtime="$7"
-            aot_runtime_output="$8"
-            aot_runtime_name="$9"
-            static_aot_runtime_link_config="${10}"
-            aot_runtime_link_config_output="${11}"
-            aot_runtime_link_config_name="${12}"
 
             mkdir -p "$(dirname "$dso_output")" "$(dirname "$config_output")" "$stdlib_output"
             cp "$shared_library" "$dso_output"
             cp -R "$dslx_stdlib"/. "$stdlib_output"
             printf 'dso_path = "%s"\\ndslx_stdlib_path = "dslx_stdlib"\\n' \
                 "$dso_name" > "$config_output"
-            if [[ -n "$static_aot_runtime" ]]; then
-                cp "$static_aot_runtime" "$aot_runtime_output"
-                cp "$static_aot_runtime_link_config" "$aot_runtime_link_config_output"
-                printf 'aot_runtime_path = "%s"\\n' "$aot_runtime_name" >> "$config_output"
-                printf 'aot_runtime_link_config_path = "%s"\\n' "$aot_runtime_link_config_name" >> "$config_output"
-            fi
         """,
         progress_message = "Packaging xlsynth artifact config for {}".format(ctx.label),
     )
-    packaged_files = [config_output, dso_output, stdlib_output] + optional_outputs
+    packaged_files = [config_output, dso_output, stdlib_output]
     return DefaultInfo(
         files = depset([config_output]),
         runfiles = ctx.runfiles(files = packaged_files),
@@ -771,8 +725,6 @@ xlsynth_artifact_config = rule(
         "dso_name": attr.string(mandatory = True),
         "dslx_stdlib": attr.label(mandatory = True),
         "shared_library": attr.label(allow_single_file = True, mandatory = True),
-        "static_aot_runtime": attr.label(allow_single_file = True),
-        "static_aot_runtime_link_config": attr.label(allow_single_file = True),
     },
 )
 


### PR DESCRIPTION
This is replaced by the new compiler based on cranelift which is much easier to support and generally faster.