### PR TITLE
Let each DSLX library report its selected XLS and XLSynth versions

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -45,38 +45,21 @@ selected_toolchain_test_suite(
 )
 
 filegroup(
-    name = "selected_toolchain_default_metadata",
-    srcs = ["//sample:selected_toolchain_test_default_library"],
-    output_group = "selected_toolchain",
-)
-
-filegroup(
-    name = "selected_toolchain_override_metadata",
-    srcs = ["//sample:selected_toolchain_test_override_library"],
-    output_group = "selected_toolchain",
-)
-
-filegroup(
-    name = "selected_toolchain_git_metadata",
-    srcs = ["//sample:selected_toolchain_test_git_library"],
-    output_group = "selected_toolchain",
-)
-
-filegroup(
-    name = "selected_toolchain_unpinned_metadata",
-    srcs = ["//sample:selected_toolchain_test_unpinned_library"],
+    name = "selected_toolchain_test_metadata",
+    srcs = [
+        "//sample:selected_toolchain_test_default_library",
+        "//sample:selected_toolchain_test_git_library",
+        "//sample:selected_toolchain_test_mixed_library",
+        "//sample:selected_toolchain_test_override_library",
+        "//sample:selected_toolchain_test_unpinned_library",
+    ],
     output_group = "selected_toolchain",
 )
 
 py_test(
     name = "selected_toolchain_exports_test",
     srcs = ["selected_toolchain_exports_test.py"],
-    data = [
-        ":selected_toolchain_default_metadata",
-        ":selected_toolchain_git_metadata",
-        ":selected_toolchain_override_metadata",
-        ":selected_toolchain_unpinned_metadata",
-    ],
+    data = [":selected_toolchain_test_metadata"],
     deps = ["@rules_python//python/runfiles"],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -48,6 +48,7 @@ filegroup(
     name = "selected_toolchain_test_metadata",
     srcs = [
         "//sample:selected_toolchain_test_default_library",
+        "//sample:selected_toolchain_test_external_library",
         "//sample:selected_toolchain_test_git_library",
         "//sample:selected_toolchain_test_legacy_library",
         "//sample:selected_toolchain_test_mixed_library",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_python//python:defs.bzl", "py_test")
+load("//:selected_toolchain_test.bzl", "selected_toolchain_test_suite")
 load("//:trusted_identity_boundary_test.bzl", "trusted_identity_boundary_test_suite")
 
 py_test(
@@ -37,6 +38,46 @@ py_test(
 
 trusted_identity_boundary_test_suite(
     name = "trusted_identity_boundary_test",
+)
+
+selected_toolchain_test_suite(
+    name = "selected_toolchain_test",
+)
+
+filegroup(
+    name = "selected_toolchain_default_metadata",
+    srcs = ["//sample:selected_toolchain_test_default_library"],
+    output_group = "selected_toolchain",
+)
+
+filegroup(
+    name = "selected_toolchain_override_metadata",
+    srcs = ["//sample:selected_toolchain_test_override_library"],
+    output_group = "selected_toolchain",
+)
+
+filegroup(
+    name = "selected_toolchain_git_metadata",
+    srcs = ["//sample:selected_toolchain_test_git_library"],
+    output_group = "selected_toolchain",
+)
+
+filegroup(
+    name = "selected_toolchain_unpinned_metadata",
+    srcs = ["//sample:selected_toolchain_test_unpinned_library"],
+    output_group = "selected_toolchain",
+)
+
+py_test(
+    name = "selected_toolchain_exports_test",
+    srcs = ["selected_toolchain_exports_test.py"],
+    data = [
+        ":selected_toolchain_default_metadata",
+        ":selected_toolchain_git_metadata",
+        ":selected_toolchain_override_metadata",
+        ":selected_toolchain_unpinned_metadata",
+    ],
+    deps = ["@rules_python//python/runfiles"],
 )
 
 genrule(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@rules_python//python:defs.bzl", "py_test")
-load("//:selected_toolchain_test.bzl", "selected_toolchain_test_suite")
 load("//:trusted_identity_boundary_test.bzl", "trusted_identity_boundary_test_suite")
 
 py_test(
@@ -40,28 +39,15 @@ trusted_identity_boundary_test_suite(
     name = "trusted_identity_boundary_test",
 )
 
-selected_toolchain_test_suite(
+test_suite(
     name = "selected_toolchain_test",
-)
-
-filegroup(
-    name = "selected_toolchain_test_metadata",
-    srcs = [
-        "//sample:selected_toolchain_test_default_library",
-        "//sample:selected_toolchain_test_external_library",
-        "//sample:selected_toolchain_test_git_library",
-        "//sample:selected_toolchain_test_legacy_library",
-        "//sample:selected_toolchain_test_mixed_library",
-        "//sample:selected_toolchain_test_override_library",
-        "//sample:selected_toolchain_test_unpinned_library",
-    ],
-    output_group = "selected_toolchain",
+    tests = ["//selected_toolchain_tests:selected_toolchain_test"],
 )
 
 py_test(
     name = "selected_toolchain_exports_test",
     srcs = ["selected_toolchain_exports_test.py"],
-    data = [":selected_toolchain_test_metadata"],
+    data = ["//sample:selected_toolchain_test_metadata"],
     deps = ["@rules_python//python/runfiles"],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -47,7 +47,7 @@ test_suite(
 py_test(
     name = "selected_toolchain_exports_test",
     srcs = ["selected_toolchain_exports_test.py"],
-    data = ["//sample:selected_toolchain_test_metadata"],
+    data = ["//selected_toolchain_tests:selected_toolchain_test_metadata"],
     deps = ["@rules_python//python/runfiles"],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -49,6 +49,7 @@ filegroup(
     srcs = [
         "//sample:selected_toolchain_test_default_library",
         "//sample:selected_toolchain_test_git_library",
+        "//sample:selected_toolchain_test_legacy_library",
         "//sample:selected_toolchain_test_mixed_library",
         "//sample:selected_toolchain_test_override_library",
         "//sample:selected_toolchain_test_unpinned_library",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,18 +24,8 @@ xls.toolchain(
     xls_version = "0.40.0",
     xlsynth_driver_version = "0.36.0",
 )
-
-# Use compatible published Git revisions so this fixture's generated runtime
-# remains fetchable even when a consumer prefetches every external repository.
-xls.toolchain(
-    name = "rules_xlsynth_selected_git_test",
-    artifact_source = "download_only",
-    xls_git_revision = "4089AC95A5119C290C4C1798313BE6B4FEC28B63",
-    xlsynth_driver_git_revision = "ABF357906F1B0B9877EEC6097B0F9C458F8D09A8",
-)
 use_repo(
     xls,
-    "rules_xlsynth_selected_git_test_toolchain",
     "rules_xlsynth_selftest_xls_runtime",
     "rules_xlsynth_selftest_xls_toolchain",
     "workspace_override_xls_runtime",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,8 +24,17 @@ xls.toolchain(
     xls_version = "0.40.0",
     xlsynth_driver_version = "0.36.0",
 )
+
+# Exercise generated Git producer declarations without materializing a runtime.
+xls.toolchain(
+    name = "rules_xlsynth_selected_git_test",
+    artifact_source = "download_only",
+    xls_git_revision = "ABCDEF0123456789ABCDEF0123456789ABCDEF01",
+    xlsynth_driver_git_revision = "1234567890ABCDEF1234567890ABCDEF12345678",
+)
 use_repo(
     xls,
+    "rules_xlsynth_selected_git_test_toolchain",
     "rules_xlsynth_selftest_xls_runtime",
     "rules_xlsynth_selftest_xls_toolchain",
     "workspace_override_xls_runtime",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,12 +25,13 @@ xls.toolchain(
     xlsynth_driver_version = "0.36.0",
 )
 
-# Exercise generated Git producer declarations without materializing a runtime.
+# Use compatible published Git revisions so this fixture's generated runtime
+# remains fetchable even when a consumer prefetches every external repository.
 xls.toolchain(
     name = "rules_xlsynth_selected_git_test",
     artifact_source = "download_only",
-    xls_git_revision = "ABCDEF0123456789ABCDEF0123456789ABCDEF01",
-    xlsynth_driver_git_revision = "1234567890ABCDEF1234567890ABCDEF12345678",
+    xls_git_revision = "4089AC95A5119C290C4C1798313BE6B4FEC28B63",
+    xlsynth_driver_git_revision = "ABF357906F1B0B9877EEC6097B0F9C458F8D09A8",
 )
 use_repo(
     xls,

--- a/README.md
+++ b/README.md
@@ -179,8 +179,20 @@ dslx_to_pipeline(
 Each `dslx_library` also exposes the producer pins selected by that specific
 library. The public `DslxSelectedToolchainInfo` provider, exported by
 `@rules_xlsynth//:rules.bzl`, contains `xls_pin`, `xlsynth_crate_pin`, and the
-opt-in `metadata` output. A library's explicit `xls_bundle` override takes
-precedence over the registered default for this metadata.
+opt-in `metadata` output. A pipeline override does not change the toolchain
+selected by its dependency. To select the legacy producer pins for a library,
+apply the override to that library itself:
+
+```starlark
+dslx_library(
+    name = "my_legacy_dslx_library",
+    srcs = ["my_dslx_library.x"],
+    xls_bundle = "@legacy_xls_toolchain//:bundle",
+)
+```
+
+The overridden library reports XLS `v0.37.0` and XLSynth `v0.32.0`; a library
+without its own override continues to report the registered default.
 
 In Starlark, each available producer pin is a struct accessed through
 `provider.xls_pin.kind` and `provider.xls_pin.value` or the corresponding
@@ -191,6 +203,7 @@ typecheck output:
 
 ```shell
 bazel build --output_groups=selected_toolchain //path:my_dslx_library
+bazel build --output_groups=selected_toolchain //path:my_legacy_dslx_library
 ```
 
 The generated `<target>.selected_toolchain.json` contains separately versioned

--- a/README.md
+++ b/README.md
@@ -176,6 +176,36 @@ dslx_to_pipeline(
 )
 ```
 
+Each `dslx_library` also exposes the producer pins selected by that specific
+library. The public `DslxSelectedToolchainInfo` provider, exported by
+`@rules_xlsynth//:rules.bzl`, contains `xls_pin`, `xlsynth_crate_pin`, and the
+opt-in `metadata` output. A library's explicit `xls_bundle` override takes
+precedence over the registered default for this metadata.
+
+Request the machine-readable output without building the library's normal
+typecheck output:
+
+```shell
+bazel build --output_groups=selected_toolchain //path:my_dslx_library
+```
+
+The generated `<target>.selected_toolchain.json` contains separately versioned
+producer pins:
+
+```json
+{
+  "schema_version": 1,
+  "xls_pin": {"kind": "release_tag", "value": "v0.40.0"},
+  "xlsynth_crate_pin": {"kind": "release_tag", "value": "v0.36.0"}
+}
+```
+
+Git-pinned producers use `"kind": "git_revision"` with a lowercase,
+40-character revision. Versionless local bundles report unavailable pins as
+`null`. This output describes declared toolchain configuration; unlike
+`resolved_identity.json`, it does not authenticate installed or local
+executable contents.
+
 Artifact-path build settings such as
 `--@rules_xlsynth//config:driver_path=...`,
 `--@rules_xlsynth//config:tools_path=...`,

--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ library. The public `DslxSelectedToolchainInfo` provider, exported by
 opt-in `metadata` output. A library's explicit `xls_bundle` override takes
 precedence over the registered default for this metadata.
 
+In Starlark, each available producer pin is a struct accessed through
+`provider.xls_pin.kind` and `provider.xls_pin.value` or the corresponding
+`provider.xlsynth_crate_pin` fields.
+
 Request the machine-readable output without building the library's normal
 typecheck output:
 
@@ -202,9 +206,10 @@ producer pins:
 
 Git-pinned producers use `"kind": "git_revision"` with a lowercase,
 40-character revision. Versionless local bundles report unavailable pins as
-`null`. This output describes declared toolchain configuration; unlike
-`resolved_identity.json`, it does not authenticate installed or local
-executable contents.
+`null`. This output describes declared configuration and does not authenticate
+executable contents. Trusted `resolved_identity.json` authenticates only
+downloaded artifacts; neither metadata mechanism authenticates installed or
+local executables.
 
 Artifact-path build settings such as
 `--@rules_xlsynth//config:driver_path=...`,

--- a/README.md
+++ b/README.md
@@ -218,9 +218,10 @@ producer pins:
 ```
 
 Git-pinned producers use `"kind": "git_revision"` with a lowercase,
-40-character revision. Versionless local bundles report unavailable pins as
-`null`. This output describes declared configuration and does not authenticate
-executable contents. Trusted `resolved_identity.json` authenticates only
+40-character revision. Each producer is independently `null` when its identity
+is unavailable, including versionless local bundles and older externally
+defined toolchains. This output describes declared configuration and does not
+authenticate executable contents. Trusted `resolved_identity.json` authenticates only
 downloaded artifacts; neither metadata mechanism authenticates installed or
 local executables.
 

--- a/dslx_provider.bzl
+++ b/dslx_provider.bzl
@@ -99,13 +99,15 @@ def _dslx_library_impl(ctx):
         use_default_shell_env = False,
     )
 
+    xls_pin = getattr(toolchain, "xls_pin", None)
+    xlsynth_crate_pin = getattr(toolchain, "xlsynth_crate_pin", None)
     selected_toolchain_metadata = ctx.actions.declare_file(ctx.label.name + ".selected_toolchain.json")
     ctx.actions.write(
         output = selected_toolchain_metadata,
         content = json.encode({
             "schema_version": 1,
-            "xls_pin": toolchain.xls_pin,
-            "xlsynth_crate_pin": toolchain.xlsynth_crate_pin,
+            "xls_pin": xls_pin,
+            "xlsynth_crate_pin": xlsynth_crate_pin,
         }) + "\n",
     )
 
@@ -114,8 +116,8 @@ def _dslx_library_impl(ctx):
         DefaultInfo(files = depset([typecheck_output])),
         DslxSelectedToolchainInfo(
             metadata = selected_toolchain_metadata,
-            xls_pin = toolchain.xls_pin,
-            xlsynth_crate_pin = toolchain.xlsynth_crate_pin,
+            xls_pin = xls_pin,
+            xlsynth_crate_pin = xlsynth_crate_pin,
         ),
         OutputGroupInfo(selected_toolchain = depset([selected_toolchain_metadata])),
     ]

--- a/dslx_provider.bzl
+++ b/dslx_provider.bzl
@@ -22,21 +22,10 @@ DslxSelectedToolchainInfo = provider(
     doc = "Declared, unauthenticated producer pins selected by one DSLX library.",
     fields = {
         "metadata": "Opt-in JSON artifact containing the declared selected producer pins.",
-        "xls_pin": "Canonical declared XLS producer pin, or None when unavailable.",
-        "xlsynth_crate_pin": "Canonical declared XLSynth producer pin, or None when unavailable.",
+        "xls_pin": "Declared XLS producer struct with .kind and .value, or None when unavailable.",
+        "xlsynth_crate_pin": "Declared XLSynth producer struct with .kind and .value, or None when unavailable.",
     },
 )
-
-def _producer_pin_json(pin):
-    """Serializes a configured producer pin, preserving an unavailable pin as null."""
-    if pin == None:
-        value = None
-    else:
-        value = {
-            "kind": pin.kind,
-            "value": pin.value,
-        }
-    return value
 
 def make_dag_entry(srcs, deps, label):
     return struct(
@@ -115,8 +104,8 @@ def _dslx_library_impl(ctx):
         output = selected_toolchain_metadata,
         content = json.encode({
             "schema_version": 1,
-            "xls_pin": _producer_pin_json(toolchain.xls_pin),
-            "xlsynth_crate_pin": _producer_pin_json(toolchain.xlsynth_crate_pin),
+            "xls_pin": toolchain.xls_pin,
+            "xlsynth_crate_pin": toolchain.xlsynth_crate_pin,
         }) + "\n",
     )
 

--- a/dslx_provider.bzl
+++ b/dslx_provider.bzl
@@ -9,6 +9,7 @@ load(
     "declare_xls_toolchain_toml",
     "get_selected_tools_toolchain",
     "get_tool_artifact_inputs",
+    "normalize_selected_producer_pin",
 )
 
 DslxInfo = provider(
@@ -99,8 +100,15 @@ def _dslx_library_impl(ctx):
         use_default_shell_env = False,
     )
 
-    xls_pin = getattr(toolchain, "xls_pin", None)
-    xlsynth_crate_pin = getattr(toolchain, "xlsynth_crate_pin", None)
+    xls_pin = normalize_selected_producer_pin(
+        getattr(toolchain, "xls_pin", None),
+        "XLS pin",
+        require_xls_release = True,
+    )
+    xlsynth_crate_pin = normalize_selected_producer_pin(
+        getattr(toolchain, "xlsynth_crate_pin", None),
+        "XLSynth crate pin",
+    )
     selected_toolchain_metadata = ctx.actions.declare_file(ctx.label.name + ".selected_toolchain.json")
     ctx.actions.write(
         output = selected_toolchain_metadata,

--- a/dslx_provider.bzl
+++ b/dslx_provider.bzl
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+"""Exposes DSLX source dependencies and each library's declared toolchain pins."""
+
 load(":env_helpers.bzl", "python_runner_source")
 load(
     ":xls_toolchain.bzl",
@@ -16,6 +18,25 @@ DslxInfo = provider(
     },
 )
 
+DslxSelectedToolchainInfo = provider(
+    doc = "Declared, unauthenticated producer pins selected by one DSLX library.",
+    fields = {
+        "metadata": "Opt-in JSON artifact containing the declared selected producer pins.",
+        "xls_pin": "Canonical declared XLS producer pin, or None when unavailable.",
+        "xlsynth_crate_pin": "Canonical declared XLSynth producer pin, or None when unavailable.",
+    },
+)
+
+def _producer_pin_json(pin):
+    """Serializes a configured producer pin, preserving an unavailable pin as null."""
+    if pin == None:
+        value = None
+    else:
+        value = {
+            "kind": pin.kind,
+            "value": pin.value,
+        }
+    return value
 
 def make_dag_entry(srcs, deps, label):
     return struct(
@@ -23,7 +44,6 @@ def make_dag_entry(srcs, deps, label):
         deps = tuple(deps),
         label = label,
     )
-
 
 def make_dslx_info(
         new_entries = (),
@@ -35,7 +55,6 @@ def make_dslx_info(
             transitive = [x.dag for x in old_infos],
         ),
     )
-
 
 def _dslx_library_impl(ctx):
     """Produces a DAG for the given target.
@@ -91,11 +110,26 @@ def _dslx_library_impl(ctx):
         use_default_shell_env = False,
     )
 
+    selected_toolchain_metadata = ctx.actions.declare_file(ctx.label.name + ".selected_toolchain.json")
+    ctx.actions.write(
+        output = selected_toolchain_metadata,
+        content = json.encode({
+            "schema_version": 1,
+            "xls_pin": _producer_pin_json(toolchain.xls_pin),
+            "xlsynth_crate_pin": _producer_pin_json(toolchain.xlsynth_crate_pin),
+        }) + "\n",
+    )
+
     return [
         dslx_info,
         DefaultInfo(files = depset([typecheck_output])),
+        DslxSelectedToolchainInfo(
+            metadata = selected_toolchain_metadata,
+            xls_pin = toolchain.xls_pin,
+            xlsynth_crate_pin = toolchain.xlsynth_crate_pin,
+        ),
+        OutputGroupInfo(selected_toolchain = depset([selected_toolchain_metadata])),
     ]
-
 
 dslx_library = rule(
     doc = "Define a DSLX module.",

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -264,6 +264,8 @@ def _toolchain_build_file(
         installed_driver_root_prefix,
         local_driver_path,
         rustup_path,
+        xls_git_revision,
+        xls_version,
         xlsynth_driver_git_revision,
         xlsynth_driver_version):
     action_env_attrs = "".join([
@@ -285,6 +287,12 @@ def _toolchain_build_file(
         _string_attr_line("xlsynth_driver_git_revision", xlsynth_driver_git_revision),
         _string_attr_line("xlsynth_driver_version", xlsynth_driver_version),
     ])
+    bundle_producer_attrs = "".join([
+        _string_attr_line("xls_git_revision", xls_git_revision),
+        _string_attr_line("xls_version", xls_version),
+        _string_attr_line("xlsynth_driver_git_revision", xlsynth_driver_git_revision),
+        _string_attr_line("xlsynth_driver_version", xlsynth_driver_version),
+    ])
     return """# SPDX-License-Identifier: Apache-2.0
 
 load("@rules_xlsynth//:xls_toolchain.bzl", "xls_bundle", "xls_toolchain", "xlsynth_driver_binary")
@@ -303,7 +311,7 @@ xls_bundle(
     driver_supports_sv_enum_case_naming_policy = {driver_supports_sv_enum_case_naming_policy},
     driver_supports_sv_struct_field_ordering = {driver_supports_sv_struct_field_ordering},
     runtime = "@{runtime_repo_name}//:runtime",
-    visibility = ["//visibility:public"],
+{bundle_producer_attrs}    visibility = ["//visibility:public"],
 )
 
 alias(
@@ -328,6 +336,7 @@ toolchain(
         action_env_attrs = action_env_attrs,
         action_path = _quoted(action_path),
         allow_xls_pin_mismatch = "True" if allow_xls_pin_mismatch else "False",
+        bundle_producer_attrs = bundle_producer_attrs,
         driver_attrs = driver_attrs,
         driver_supports_sv_enum_case_naming_policy = "True" if _toolchain_driver_supports_sv_enum_case_naming_policy(artifact_source, local_driver_path, xlsynth_driver_git_revision, xlsynth_driver_version) else "False",
         driver_supports_sv_struct_field_ordering = "True" if _toolchain_driver_supports_sv_struct_field_ordering(artifact_source, local_driver_path, xlsynth_driver_git_revision, xlsynth_driver_version) else "False",
@@ -494,6 +503,8 @@ def _toolchain_repo_impl(repo_ctx):
             installed_driver_root_prefix = repo_ctx.attr.installed_driver_root_prefix,
             local_driver_path = repo_ctx.attr.local_driver_path,
             rustup_path = "" if rustup == None else str(rustup),
+            xls_git_revision = repo_ctx.attr.xls_git_revision,
+            xls_version = repo_ctx.attr.xls_version,
             xlsynth_driver_git_revision = repo_ctx.attr.xlsynth_driver_git_revision,
             xlsynth_driver_version = repo_ctx.attr.xlsynth_driver_version,
         ),

--- a/registered_toolchain_smoke.py
+++ b/registered_toolchain_smoke.py
@@ -52,7 +52,7 @@ def copy_runfile(source_name, dest):
     shutil.copy2(rules_xlsynth_source_file(source_name), dest)
 
 
-def create_minimal_rules_xlsynth_repo(repo_root):
+def create_minimal_rules_xlsynth_repo(repo_root, include_dslx = False):
     repo_root.mkdir()
     write_text_file(
         repo_root / "MODULE.bazel",
@@ -76,12 +76,13 @@ toolchain_type(
     )
     copy_runfile("extensions.bzl", repo_root / "extensions.bzl")
     copy_runfile("xls_toolchain.bzl", repo_root / "xls_toolchain.bzl")
-    copy_runfile("dslx_provider.bzl", repo_root / "dslx_provider.bzl")
-    copy_runfile("env_helpers.bzl", repo_root / "env_helpers.bzl")
     copy_runfile("materialize_xls_bundle.py", repo_root / "materialize_xls_bundle.py")
-    config_root = repo_root / "config"
-    config_root.mkdir()
-    copy_runfile("config/BUILD.bazel", config_root / "BUILD.bazel")
+    if include_dslx:
+        copy_runfile("dslx_provider.bzl", repo_root / "dslx_provider.bzl")
+        copy_runfile("env_helpers.bzl", repo_root / "env_helpers.bzl")
+        config_root = repo_root / "config"
+        config_root.mkdir()
+        copy_runfile("config/BUILD.bazel", config_root / "BUILD.bazel")
 
 
 def build_minimal_shared_library(output_path):
@@ -495,7 +496,7 @@ class RegisteredRuntimeOnlyTest(unittest.TestCase):
             write_versioned_driver(installed_driver, "version-one", driver_version)
 
             rules_xlsynth_root = root / "rules_xlsynth"
-            create_minimal_rules_xlsynth_repo(rules_xlsynth_root)
+            create_minimal_rules_xlsynth_repo(rules_xlsynth_root, include_dslx = True)
             local_bundle = create_installed_runtime_bundle(root / "installed_tools", "0.38.0")
             workspace_root = root / "workspace"
             create_auto_installed_workspace(

--- a/registered_toolchain_smoke.py
+++ b/registered_toolchain_smoke.py
@@ -226,7 +226,8 @@ def create_auto_installed_workspace(
         local_bundle,
         installed_driver_root_prefix,
         xls_version = "0.38.0",
-        driver_version = "0.33.0"):
+        driver_version = "0.33.0",
+        include_dslx = False):
     workspace_root.mkdir()
     write_text_file(
         workspace_root / "MODULE.bazel",
@@ -262,18 +263,19 @@ register_toolchains("@lazy_xls_toolchain//:all")
             xls_version = xls_version,
         ).lstrip(),
     )
-    write_text_file(
-        workspace_root / "BUILD.bazel",
-        """
+    if include_dslx:
+        build_content = """
 load("@rules_xlsynth//:dslx_provider.bzl", "dslx_library")
 
 dslx_library(
     name = "installed_auto_library",
     srcs = ["installed_auto.x"],
 )
-""".lstrip(),
-    )
-    write_text_file(workspace_root / "installed_auto.x", "pub fn id(x: u1) -> u1 { x }\n")
+""".lstrip()
+        write_text_file(workspace_root / "installed_auto.x", "pub fn id(x: u1) -> u1 { x }\n")
+    else:
+        build_content = ""
+    write_text_file(workspace_root / "BUILD.bazel", build_content)
 
 
 def run_nested_bazel(bazel_path, output_user_root, workspace_root, env, args):
@@ -451,6 +453,18 @@ class RegisteredRuntimeOnlyTest(unittest.TestCase):
             env = dict(os.environ)
             env["PATH"] = minimal_tool_path_env(bazel_path)
             output_user_root = root / "bazel_output_user_root"
+            root_package = run_nested_bazel(
+                bazel_path,
+                output_user_root,
+                workspace_root,
+                env,
+                ["query", "//:all"],
+            )
+            self.assertEqual(
+                root_package.returncode,
+                0,
+                "{}\n{}".format(root_package.stdout, root_package.stderr),
+            )
 
             first_result = run_nested_bazel(
                 bazel_path,
@@ -505,6 +519,7 @@ class RegisteredRuntimeOnlyTest(unittest.TestCase):
                 local_bundle,
                 installed_driver_root_prefix,
                 driver_version = driver_version,
+                include_dslx = True,
             )
             git_producer_revisions = {
                 "xls_git_revision": "4089AC95A5119C290C4C1798313BE6B4FEC28B63",

--- a/registered_toolchain_smoke.py
+++ b/registered_toolchain_smoke.py
@@ -10,6 +10,7 @@
 # happens only for driver-backed targets and that local or installed driver
 # files are declared Bazel action inputs.
 
+import json
 import os
 from pathlib import Path
 import shutil
@@ -75,7 +76,12 @@ toolchain_type(
     )
     copy_runfile("extensions.bzl", repo_root / "extensions.bzl")
     copy_runfile("xls_toolchain.bzl", repo_root / "xls_toolchain.bzl")
+    copy_runfile("dslx_provider.bzl", repo_root / "dslx_provider.bzl")
+    copy_runfile("env_helpers.bzl", repo_root / "env_helpers.bzl")
     copy_runfile("materialize_xls_bundle.py", repo_root / "materialize_xls_bundle.py")
+    config_root = repo_root / "config"
+    config_root.mkdir()
+    copy_runfile("config/BUILD.bazel", config_root / "BUILD.bazel")
 
 
 def build_minimal_shared_library(output_path):
@@ -255,7 +261,18 @@ register_toolchains("@lazy_xls_toolchain//:all")
             xls_version = xls_version,
         ).lstrip(),
     )
-    write_text_file(workspace_root / "BUILD.bazel", "")
+    write_text_file(
+        workspace_root / "BUILD.bazel",
+        """
+load("@rules_xlsynth//:dslx_provider.bzl", "dslx_library")
+
+dslx_library(
+    name = "installed_auto_library",
+    srcs = ["installed_auto.x"],
+)
+""".lstrip(),
+    )
+    write_text_file(workspace_root / "installed_auto.x", "pub fn id(x: u1) -> u1 { x }\n")
 
 
 def run_nested_bazel(bazel_path, output_user_root, workspace_root, env, args):
@@ -488,6 +505,22 @@ class RegisteredRuntimeOnlyTest(unittest.TestCase):
                 installed_driver_root_prefix,
                 driver_version = driver_version,
             )
+            git_producer_revisions = {
+                "xls_git_revision": "4089AC95A5119C290C4C1798313BE6B4FEC28B63",
+                "xlsynth_driver_git_revision": "ABF357906F1B0B9877EEC6097B0F9C458F8D09A8",
+            }
+            with (workspace_root / "MODULE.bazel").open("a", encoding = "utf-8") as module_file:
+                module_file.write(
+                    """
+xls.toolchain(
+    name = "git_probe_xls",
+    artifact_source = "download_only",
+    xls_git_revision = "{xls_git_revision}",
+    xlsynth_driver_git_revision = "{xlsynth_driver_git_revision}",
+)
+use_repo(xls, "git_probe_xls_toolchain")
+""".format(**git_producer_revisions)
+                )
             env = dict(os.environ)
             env["PATH"] = minimal_tool_path_env(bazel_path)
             output_user_root = root / "bazel_output_user_root"
@@ -498,12 +531,46 @@ class RegisteredRuntimeOnlyTest(unittest.TestCase):
                 env,
                 ["query", "@lazy_xls_toolchain//:all"],
             )
-
+            combined_output = "{}\n{}".format(result.stdout, result.stderr)
+            self.assertEqual(result.returncode, 0, combined_output)
+            self.assertIn("@lazy_xls_toolchain//:xlsynth-driver", combined_output)
             staged_host_drivers = paths_with_basename(output_user_root, "host_xlsynth-driver")
+            git_result = run_nested_bazel(
+                bazel_path,
+                output_user_root,
+                workspace_root,
+                env,
+                ["query", "--output=build", "@git_probe_xls_toolchain//:bundle"],
+            )
+            self.assertEqual(git_result.returncode, 0, "{}\n{}".format(git_result.stdout, git_result.stderr))
+            for attribute, revision in git_producer_revisions.items():
+                self.assertIn('{} = "{}"'.format(attribute, revision), git_result.stdout)
+            metadata_result = run_nested_bazel(
+                bazel_path,
+                output_user_root,
+                workspace_root,
+                env,
+                ["build", "--output_groups=selected_toolchain", "//:installed_auto_library"],
+            )
+            self.assertEqual(
+                metadata_result.returncode,
+                0,
+                "{}\n{}".format(metadata_result.stdout, metadata_result.stderr),
+            )
+            metadata_path = workspace_root / "bazel-bin" / "installed_auto_library.selected_toolchain.json"
+            metadata = json.loads(metadata_path.read_text(encoding = "utf-8"))
+            typecheck_path = workspace_root / "bazel-bin" / "installed_auto_library.typecheck"
+            typecheck_was_executed = typecheck_path.exists()
 
-        combined_output = "{}\n{}".format(result.stdout, result.stderr)
-        self.assertEqual(result.returncode, 0, combined_output)
-        self.assertIn("@lazy_xls_toolchain//:xlsynth-driver", combined_output)
+        self.assertEqual(
+            metadata,
+            {
+                "schema_version": 1,
+                "xls_pin": {"kind": "release_tag", "value": "v0.38.0"},
+                "xlsynth_crate_pin": {"kind": "release_tag", "value": "v0.33.0"},
+            },
+        )
+        self.assertFalse(typecheck_was_executed)
         self.assertEqual(staged_host_drivers, [])
 
     def test_01_toolchain_package_load_does_not_materialize_driver(self):

--- a/registered_toolchain_smoke.py
+++ b/registered_toolchain_smoke.py
@@ -453,25 +453,13 @@ class RegisteredRuntimeOnlyTest(unittest.TestCase):
             env = dict(os.environ)
             env["PATH"] = minimal_tool_path_env(bazel_path)
             output_user_root = root / "bazel_output_user_root"
-            root_package = run_nested_bazel(
-                bazel_path,
-                output_user_root,
-                workspace_root,
-                env,
-                ["query", "//:all"],
-            )
-            self.assertEqual(
-                root_package.returncode,
-                0,
-                "{}\n{}".format(root_package.stdout, root_package.stderr),
-            )
 
             first_result = run_nested_bazel(
                 bazel_path,
                 output_user_root,
                 workspace_root,
                 env,
-                ["build", "@lazy_xls_toolchain//:xlsynth-driver"],
+                ["build", "//:all", "@lazy_xls_toolchain//:xlsynth-driver"],
             )
             self.assertEqual(first_result.returncode, 0, "{}\n{}".format(first_result.stdout, first_result.stderr))
             driver_output = query_single_output_file(

--- a/rules.bzl
+++ b/rules.bzl
@@ -9,6 +9,7 @@ load(
 load(
     ":dslx_provider.bzl",
     _DslxInfo = "DslxInfo",
+    _DslxSelectedToolchainInfo = "DslxSelectedToolchainInfo",
     _dslx_library = "dslx_library",
 )
 load(
@@ -44,6 +45,7 @@ load(
 load(":ir_to_gates.bzl", _ir_to_gates = "ir_to_gates")
 
 DslxInfo = _DslxInfo
+DslxSelectedToolchainInfo = _DslxSelectedToolchainInfo
 dslx_library = _dslx_library
 dslx_test = _dslx_test
 dslx_fmt_test = _dslx_fmt_test

--- a/run_presubmit.py
+++ b/run_presubmit.py
@@ -443,9 +443,38 @@ def run_toolchain_helper_tests(config: PresubmitConfig):
             '//:download_release_test',
             '//:external_bundle_exports_test',
             '//:trusted_identity_boundary_test',
+            '//:selected_toolchain_test',
+            '//:selected_toolchain_exports_test',
         ),
         config,
     )
+
+
+@register
+def run_generated_git_toolchain_declarations(config: PresubmitConfig):
+    """Validate extension-generated Git declarations without resolving artifacts."""
+    cmdline = [
+        'bazel',
+        '--bazelrc=/dev/null',
+        'query',
+        '--output=build',
+        '@rules_xlsynth_selected_git_test_toolchain//:bundle',
+    ]
+    print('Running command: ' + subprocess.list2cmdline(cmdline))
+    result = subprocess.run(
+        cmdline,
+        check = True,
+        cwd = str(config.repo_root),
+        stdout = subprocess.PIPE,
+        encoding = 'utf-8',
+    )
+    expected_pins = {
+        'xls_git_revision': 'ABCDEF0123456789ABCDEF0123456789ABCDEF01',
+        'xlsynth_driver_git_revision': '1234567890ABCDEF1234567890ABCDEF12345678',
+    }
+    for attribute, revision in expected_pins.items():
+        if '{} = "{}"'.format(attribute, revision) not in result.stdout:
+            raise ValueError('Generated XLS bundle is missing {} {}'.format(attribute, revision))
 
 
 @register

--- a/run_presubmit.py
+++ b/run_presubmit.py
@@ -469,8 +469,8 @@ def run_generated_git_toolchain_declarations(config: PresubmitConfig):
         encoding = 'utf-8',
     )
     expected_pins = {
-        'xls_git_revision': 'ABCDEF0123456789ABCDEF0123456789ABCDEF01',
-        'xlsynth_driver_git_revision': '1234567890ABCDEF1234567890ABCDEF12345678',
+        'xls_git_revision': '4089AC95A5119C290C4C1798313BE6B4FEC28B63',
+        'xlsynth_driver_git_revision': 'ABF357906F1B0B9877EEC6097B0F9C458F8D09A8',
     }
     for attribute, revision in expected_pins.items():
         if '{} = "{}"'.format(attribute, revision) not in result.stdout:

--- a/run_presubmit.py
+++ b/run_presubmit.py
@@ -451,33 +451,6 @@ def run_toolchain_helper_tests(config: PresubmitConfig):
 
 
 @register
-def run_generated_git_toolchain_declarations(config: PresubmitConfig):
-    """Validate extension-generated Git declarations without resolving artifacts."""
-    cmdline = [
-        'bazel',
-        '--bazelrc=/dev/null',
-        'query',
-        '--output=build',
-        '@rules_xlsynth_selected_git_test_toolchain//:bundle',
-    ]
-    print('Running command: ' + subprocess.list2cmdline(cmdline))
-    result = subprocess.run(
-        cmdline,
-        check = True,
-        cwd = str(config.repo_root),
-        stdout = subprocess.PIPE,
-        encoding = 'utf-8',
-    )
-    expected_pins = {
-        'xls_git_revision': '4089AC95A5119C290C4C1798313BE6B4FEC28B63',
-        'xlsynth_driver_git_revision': 'ABF357906F1B0B9877EEC6097B0F9C458F8D09A8',
-    }
-    for attribute, revision in expected_pins.items():
-        if '{} = "{}"'.format(attribute, revision) not in result.stdout:
-            raise ValueError('Generated XLS bundle is missing {} {}'.format(attribute, revision))
-
-
-@register
 def run_registered_toolchain_smoke(config: PresubmitConfig):
     run_python_script(config, 'registered_toolchain_smoke.py')
 

--- a/sample/BUILD.bazel
+++ b/sample/BUILD.bazel
@@ -20,7 +20,11 @@ load(
     "ir_to_gates",
     "mangle_dslx_name",
 )
-load("//:selected_toolchain_test.bzl", "selected_toolchain_test_fixtures")
+
+exports_files(
+    ["imported.x"],
+    visibility = ["//selected_toolchain_tests:__pkg__"],
+)
 
 dslx_library(
     name = "imported",
@@ -81,8 +85,6 @@ dslx_library(
     srcs = ["sample.x"],
     deps = [":imported"],
 )
-
-selected_toolchain_test_fixtures(name = "selected_toolchain_test")
 
 dslx_library(
     name = "sample_explicit_bundle",

--- a/sample/BUILD.bazel
+++ b/sample/BUILD.bazel
@@ -127,6 +127,15 @@ dslx_library(
 )
 
 dslx_library(
+    name = "selected_toolchain_test_legacy_library",
+    srcs = ["sample.x"],
+    tags = ["manual"],
+    visibility = ["//:__pkg__"],
+    xls_bundle = "//:selected_toolchain_test_legacy_bundle",
+    deps = [":imported"],
+)
+
+dslx_library(
     name = "sample_explicit_bundle",
     srcs = ["sample.x"],
     xls_bundle = "@rules_xlsynth_selftest_xls_toolchain//:bundle",

--- a/sample/BUILD.bazel
+++ b/sample/BUILD.bazel
@@ -20,6 +20,7 @@ load(
     "ir_to_gates",
     "mangle_dslx_name",
 )
+load("//:selected_toolchain_test.bzl", "selected_toolchain_test_fixtures")
 
 dslx_library(
     name = "imported",
@@ -81,77 +82,7 @@ dslx_library(
     deps = [":imported"],
 )
 
-# Keep selected-toolchain analysis fixtures beside their private DSLX source.
-dslx_library(
-    name = "selected_toolchain_test_default_library",
-    srcs = ["sample.x"],
-    tags = ["manual"],
-    visibility = ["//:__pkg__"],
-    deps = [":imported"],
-)
-
-dslx_library(
-    name = "selected_toolchain_test_override_library",
-    srcs = ["sample.x"],
-    tags = ["manual"],
-    visibility = ["//:__pkg__"],
-    xls_bundle = "//:selected_toolchain_test_override_bundle",
-    deps = [":imported"],
-)
-
-dslx_library(
-    name = "selected_toolchain_test_git_library",
-    srcs = ["sample.x"],
-    tags = ["manual"],
-    visibility = ["//:__pkg__"],
-    xls_bundle = "//:selected_toolchain_test_git_bundle",
-    deps = [":imported"],
-)
-
-dslx_library(
-    name = "selected_toolchain_test_mixed_library",
-    srcs = ["sample.x"],
-    tags = ["manual"],
-    visibility = ["//:__pkg__"],
-    xls_bundle = "//:selected_toolchain_test_mixed_bundle",
-    deps = [":imported"],
-)
-
-dslx_library(
-    name = "selected_toolchain_test_unpinned_library",
-    srcs = ["sample.x"],
-    tags = ["manual"],
-    visibility = ["//:__pkg__"],
-    xls_bundle = "//:selected_toolchain_test_unpinned_bundle",
-    deps = [":imported"],
-)
-
-dslx_library(
-    name = "selected_toolchain_test_legacy_library",
-    srcs = ["sample.x"],
-    tags = ["manual"],
-    visibility = ["//:__pkg__"],
-    xls_bundle = "//:selected_toolchain_test_legacy_bundle",
-    deps = [":imported"],
-)
-
-dslx_library(
-    name = "selected_toolchain_test_external_library",
-    srcs = ["sample.x"],
-    tags = ["manual"],
-    visibility = ["//:__pkg__"],
-    xls_bundle = "//:selected_toolchain_test_external_bundle",
-    deps = [":imported"],
-)
-
-dslx_library(
-    name = "selected_toolchain_test_invalid_external_library",
-    srcs = ["sample.x"],
-    tags = ["manual"],
-    visibility = ["//:__pkg__"],
-    xls_bundle = "//:selected_toolchain_test_invalid_external_bundle",
-    deps = [":imported"],
-)
+selected_toolchain_test_fixtures(name = "selected_toolchain_test")
 
 dslx_library(
     name = "sample_explicit_bundle",

--- a/sample/BUILD.bazel
+++ b/sample/BUILD.bazel
@@ -106,6 +106,14 @@ dslx_library(
 )
 
 dslx_library(
+    name = "selected_toolchain_test_mixed_library",
+    srcs = ["sample.x"],
+    visibility = ["//:__pkg__"],
+    xls_bundle = "//:selected_toolchain_test_mixed_bundle",
+    deps = [":imported"],
+)
+
+dslx_library(
     name = "selected_toolchain_test_unpinned_library",
     srcs = ["sample.x"],
     visibility = ["//:__pkg__"],

--- a/sample/BUILD.bazel
+++ b/sample/BUILD.bazel
@@ -81,11 +81,43 @@ dslx_library(
     deps = [":imported"],
 )
 
+# Keep selected-toolchain analysis fixtures beside their private DSLX source.
+dslx_library(
+    name = "selected_toolchain_test_default_library",
+    srcs = ["sample.x"],
+    visibility = ["//:__pkg__"],
+    deps = [":imported"],
+)
+
+dslx_library(
+    name = "selected_toolchain_test_override_library",
+    srcs = ["sample.x"],
+    visibility = ["//:__pkg__"],
+    xls_bundle = "//:selected_toolchain_test_override_bundle",
+    deps = [":imported"],
+)
+
+dslx_library(
+    name = "selected_toolchain_test_git_library",
+    srcs = ["sample.x"],
+    visibility = ["//:__pkg__"],
+    xls_bundle = "//:selected_toolchain_test_git_bundle",
+    deps = [":imported"],
+)
+
+dslx_library(
+    name = "selected_toolchain_test_unpinned_library",
+    srcs = ["sample.x"],
+    visibility = ["//:__pkg__"],
+    xls_bundle = "//:selected_toolchain_test_unpinned_bundle",
+    deps = [":imported"],
+)
+
 dslx_library(
     name = "sample_explicit_bundle",
     srcs = ["sample.x"],
-    deps = [":imported"],
     xls_bundle = "@rules_xlsynth_selftest_xls_toolchain//:bundle",
+    deps = [":imported"],
 )
 
 build_test(
@@ -178,8 +210,8 @@ dslx_test(
 
 dslx_test(
     name = "sample_explicit_bundle_test",
-    deps = [":sample_explicit_bundle"],
     xls_bundle = "@rules_xlsynth_selftest_xls_toolchain//:bundle",
+    deps = [":sample_explicit_bundle"],
 )
 
 dslx_test(

--- a/sample/BUILD.bazel
+++ b/sample/BUILD.bazel
@@ -85,6 +85,7 @@ dslx_library(
 dslx_library(
     name = "selected_toolchain_test_default_library",
     srcs = ["sample.x"],
+    tags = ["manual"],
     visibility = ["//:__pkg__"],
     deps = [":imported"],
 )
@@ -92,6 +93,7 @@ dslx_library(
 dslx_library(
     name = "selected_toolchain_test_override_library",
     srcs = ["sample.x"],
+    tags = ["manual"],
     visibility = ["//:__pkg__"],
     xls_bundle = "//:selected_toolchain_test_override_bundle",
     deps = [":imported"],
@@ -100,6 +102,7 @@ dslx_library(
 dslx_library(
     name = "selected_toolchain_test_git_library",
     srcs = ["sample.x"],
+    tags = ["manual"],
     visibility = ["//:__pkg__"],
     xls_bundle = "//:selected_toolchain_test_git_bundle",
     deps = [":imported"],
@@ -108,6 +111,7 @@ dslx_library(
 dslx_library(
     name = "selected_toolchain_test_mixed_library",
     srcs = ["sample.x"],
+    tags = ["manual"],
     visibility = ["//:__pkg__"],
     xls_bundle = "//:selected_toolchain_test_mixed_bundle",
     deps = [":imported"],
@@ -116,6 +120,7 @@ dslx_library(
 dslx_library(
     name = "selected_toolchain_test_unpinned_library",
     srcs = ["sample.x"],
+    tags = ["manual"],
     visibility = ["//:__pkg__"],
     xls_bundle = "//:selected_toolchain_test_unpinned_bundle",
     deps = [":imported"],

--- a/sample/BUILD.bazel
+++ b/sample/BUILD.bazel
@@ -136,6 +136,24 @@ dslx_library(
 )
 
 dslx_library(
+    name = "selected_toolchain_test_external_library",
+    srcs = ["sample.x"],
+    tags = ["manual"],
+    visibility = ["//:__pkg__"],
+    xls_bundle = "//:selected_toolchain_test_external_bundle",
+    deps = [":imported"],
+)
+
+dslx_library(
+    name = "selected_toolchain_test_invalid_external_library",
+    srcs = ["sample.x"],
+    tags = ["manual"],
+    visibility = ["//:__pkg__"],
+    xls_bundle = "//:selected_toolchain_test_invalid_external_bundle",
+    deps = [":imported"],
+)
+
+dslx_library(
     name = "sample_explicit_bundle",
     srcs = ["sample.x"],
     xls_bundle = "@rules_xlsynth_selftest_xls_toolchain//:bundle",

--- a/selected_toolchain_exports_test.py
+++ b/selected_toolchain_exports_test.py
@@ -84,6 +84,17 @@ class SelectedToolchainExportsTest(unittest.TestCase):
         self.assertIsNone(metadata["xls_pin"])
         self.assertIsNone(metadata["xlsynth_crate_pin"])
 
+    # Verifies: Externally supplied producer structs are normalized before export.
+    # Catches: Raw release or Git inputs bypassing the canonical producer parser.
+    def test_external_bundle_producer_fields_are_canonicalized(self):
+        metadata = self.read_metadata("sample/selected_toolchain_test_external_library.selected_toolchain.json")
+
+        self.assertEqual(metadata["xls_pin"], {"kind": "release_tag", "value": "v0.40.0"})
+        self.assertEqual(
+            metadata["xlsynth_crate_pin"],
+            {"kind": "git_revision", "value": "1234567890abcdef1234567890abcdef12345678"},
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/selected_toolchain_exports_test.py
+++ b/selected_toolchain_exports_test.py
@@ -95,6 +95,14 @@ class SelectedToolchainExportsTest(unittest.TestCase):
             {"kind": "git_revision", "value": "1234567890abcdef1234567890abcdef12345678"},
         )
 
+    # Verifies: One available producer survives when the other producer is unknown.
+    # Catches: Treating independently unavailable producer identities as all-or-nothing.
+    def test_partial_bundle_preserves_independently_missing_pin(self):
+        metadata = self.read_metadata("sample/selected_toolchain_test_partial_library.selected_toolchain.json")
+
+        self.assertEqual(metadata["xls_pin"], {"kind": "release_tag", "value": "v0.40.0"})
+        self.assertIsNone(metadata["xlsynth_crate_pin"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/selected_toolchain_exports_test.py
+++ b/selected_toolchain_exports_test.py
@@ -79,25 +79,6 @@ class SelectedToolchainExportsTest(unittest.TestCase):
         self.assertIsNone(metadata["xls_pin"])
         self.assertIsNone(metadata["xlsynth_crate_pin"])
 
-    # Verifies: Preexisting external bundle shapes remain usable without new fields.
-    # Catches: Requiring producer pins on public providers created before this feature.
-    def test_legacy_bundle_without_producer_fields_reports_missing_pins(self):
-        metadata = self.read_metadata("legacy")
-
-        self.assertIsNone(metadata["xls_pin"])
-        self.assertIsNone(metadata["xlsynth_crate_pin"])
-
-    # Verifies: Externally supplied producer structs are normalized before export.
-    # Catches: Raw release or Git inputs bypassing the canonical producer parser.
-    def test_external_bundle_producer_fields_are_canonicalized(self):
-        metadata = self.read_metadata("external")
-
-        self.assertEqual(metadata["xls_pin"], {"kind": "release_tag", "value": "v0.40.0"})
-        self.assertEqual(
-            metadata["xlsynth_crate_pin"],
-            {"kind": "git_revision", "value": "1234567890abcdef1234567890abcdef12345678"},
-        )
-
     # Verifies: One available producer survives when the other producer is unknown.
     # Catches: Treating independently unavailable producer identities as all-or-nothing.
     def test_partial_bundle_preserves_independently_missing_pin(self):
@@ -105,14 +86,6 @@ class SelectedToolchainExportsTest(unittest.TestCase):
 
         self.assertEqual(metadata["xls_pin"], {"kind": "release_tag", "value": "v0.40.0"})
         self.assertIsNone(metadata["xlsynth_crate_pin"])
-
-    # Verifies: Known XLSynth metadata remains available without XLS metadata.
-    # Catches: Making the two producer fields interdependent during JSON export.
-    def test_partial_bundle_preserves_known_driver_when_xls_is_missing(self):
-        metadata = self.read_metadata("partial_driver")
-
-        self.assertIsNone(metadata["xls_pin"])
-        self.assertEqual(metadata["xlsynth_crate_pin"], {"kind": "release_tag", "value": "v0.36.0"})
 
 
 if __name__ == "__main__":

--- a/selected_toolchain_exports_test.py
+++ b/selected_toolchain_exports_test.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests the public, opt-in selected DSLX toolchain metadata outputs."""
+
+import json
+import os
+from pathlib import Path
+import unittest
+
+from python.runfiles import runfiles
+
+
+class SelectedToolchainExportsTest(unittest.TestCase):
+    """Validates the public JSON outputs consumed outside Bazel analysis."""
+
+    def read_metadata(self, relative_path):
+        """Reads a requested metadata artifact through Bazel's runfiles contract."""
+        workspace = os.environ["TEST_WORKSPACE"]
+        path = runfiles.Create().Rlocation("{}/{}".format(workspace, relative_path))
+        return json.loads(Path(path).read_text(encoding = "utf-8"))
+
+    # Verifies: Default metadata contains separate canonical XLS/XLSynth pins.
+    # Catches: Missing schema data or conflated producer release versions.
+    def test_default_library_exposes_canonical_independent_producer_pins(self):
+        metadata = self.read_metadata("sample/selected_toolchain_test_default_library.selected_toolchain.json")
+
+        self.assertEqual(metadata["schema_version"], 1)
+        self.assertEqual(metadata["xls_pin"], {"kind": "release_tag", "value": "v0.40.0"})
+        self.assertEqual(metadata["xlsynth_crate_pin"], {"kind": "release_tag", "value": "v0.36.0"})
+
+    # Verifies: Metadata reflects the producer versions of a library override.
+    # Catches: Reporting a repository default for an explicitly overridden target.
+    def test_explicit_library_override_exposes_its_own_producer_pins(self):
+        metadata = self.read_metadata("sample/selected_toolchain_test_override_library.selected_toolchain.json")
+
+        self.assertEqual(metadata["xls_pin"], {"kind": "release_tag", "value": "v0.37.0"})
+        self.assertEqual(metadata["xlsynth_crate_pin"], {"kind": "release_tag", "value": "v0.32.0"})
+
+    # Verifies: JSON distinguishes and canonicalizes Git-revision producer pins.
+    # Catches: Emitting a release tag or uppercase revision for a Git toolchain.
+    def test_git_revisions_are_distinguished_and_normalized(self):
+        metadata = self.read_metadata("sample/selected_toolchain_test_git_library.selected_toolchain.json")
+        expected_pin = {
+            "kind": "git_revision",
+            "value": "abcdef0123456789abcdef0123456789abcdef01",
+        }
+
+        self.assertEqual(metadata["xls_pin"], expected_pin)
+        self.assertEqual(metadata["xlsynth_crate_pin"], expected_pin)
+
+    # Verifies: Local versionless toolchains report missing producer pins as null.
+    # Catches: Fabricated identity data or rejected local toolchain bundles.
+    def test_versionless_bundle_preserves_explicitly_missing_pins(self):
+        metadata = self.read_metadata("sample/selected_toolchain_test_unpinned_library.selected_toolchain.json")
+
+        self.assertIsNone(metadata["xls_pin"])
+        self.assertIsNone(metadata["xlsynth_crate_pin"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/selected_toolchain_exports_test.py
+++ b/selected_toolchain_exports_test.py
@@ -76,6 +76,14 @@ class SelectedToolchainExportsTest(unittest.TestCase):
         self.assertIsNone(metadata["xls_pin"])
         self.assertIsNone(metadata["xlsynth_crate_pin"])
 
+    # Verifies: Preexisting external bundle shapes remain usable without new fields.
+    # Catches: Requiring producer pins on public providers created before this feature.
+    def test_legacy_bundle_without_producer_fields_reports_missing_pins(self):
+        metadata = self.read_metadata("sample/selected_toolchain_test_legacy_library.selected_toolchain.json")
+
+        self.assertIsNone(metadata["xls_pin"])
+        self.assertIsNone(metadata["xlsynth_crate_pin"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/selected_toolchain_exports_test.py
+++ b/selected_toolchain_exports_test.py
@@ -13,16 +13,19 @@ from python.runfiles import runfiles
 class SelectedToolchainExportsTest(unittest.TestCase):
     """Validates the public JSON outputs consumed outside Bazel analysis."""
 
-    def read_metadata(self, relative_path):
+    def read_metadata(self, scenario):
         """Reads a requested metadata artifact through Bazel's runfiles contract."""
         workspace = os.environ["TEST_WORKSPACE"]
+        relative_path = "selected_toolchain_tests/selected_toolchain_test_{}_library.selected_toolchain.json".format(
+            scenario,
+        )
         path = runfiles.Create().Rlocation("{}/{}".format(workspace, relative_path))
         return json.loads(Path(path).read_text(encoding = "utf-8"))
 
     # Verifies: Default metadata contains separate canonical XLS/XLSynth pins.
     # Catches: Missing schema data or conflated producer release versions.
     def test_default_library_exposes_canonical_independent_producer_pins(self):
-        metadata = self.read_metadata("sample/selected_toolchain_test_default_library.selected_toolchain.json")
+        metadata = self.read_metadata("default")
 
         self.assertEqual(
             metadata,
@@ -36,7 +39,7 @@ class SelectedToolchainExportsTest(unittest.TestCase):
     # Verifies: Metadata reflects the producer versions of a library override.
     # Catches: Reporting a repository default for an explicitly overridden target.
     def test_explicit_library_override_exposes_its_own_producer_pins(self):
-        metadata = self.read_metadata("sample/selected_toolchain_test_override_library.selected_toolchain.json")
+        metadata = self.read_metadata("override")
 
         self.assertEqual(metadata["xls_pin"], {"kind": "release_tag", "value": "v0.37.0"})
         self.assertEqual(metadata["xlsynth_crate_pin"], {"kind": "release_tag", "value": "v0.32.0"})
@@ -44,7 +47,7 @@ class SelectedToolchainExportsTest(unittest.TestCase):
     # Verifies: JSON distinguishes and canonicalizes Git-revision producer pins.
     # Catches: Emitting a release tag or uppercase revision for a Git toolchain.
     def test_git_revisions_are_distinguished_and_normalized(self):
-        metadata = self.read_metadata("sample/selected_toolchain_test_git_library.selected_toolchain.json")
+        metadata = self.read_metadata("git")
         expected_xls_pin = {
             "kind": "git_revision",
             "value": "abcdef0123456789abcdef0123456789abcdef01",
@@ -60,7 +63,7 @@ class SelectedToolchainExportsTest(unittest.TestCase):
     # Verifies: A release-pinned XLS producer can pair with a Git-pinned driver.
     # Catches: Conflating independent producer identities or their representations.
     def test_release_and_git_producer_pins_can_be_mixed(self):
-        metadata = self.read_metadata("sample/selected_toolchain_test_mixed_library.selected_toolchain.json")
+        metadata = self.read_metadata("mixed")
 
         self.assertEqual(metadata["xls_pin"], {"kind": "release_tag", "value": "v0.40.0"})
         self.assertEqual(
@@ -71,7 +74,7 @@ class SelectedToolchainExportsTest(unittest.TestCase):
     # Verifies: Local versionless toolchains report missing producer pins as null.
     # Catches: Fabricated identity data or rejected local toolchain bundles.
     def test_versionless_bundle_preserves_explicitly_missing_pins(self):
-        metadata = self.read_metadata("sample/selected_toolchain_test_unpinned_library.selected_toolchain.json")
+        metadata = self.read_metadata("unpinned")
 
         self.assertIsNone(metadata["xls_pin"])
         self.assertIsNone(metadata["xlsynth_crate_pin"])
@@ -79,7 +82,7 @@ class SelectedToolchainExportsTest(unittest.TestCase):
     # Verifies: Preexisting external bundle shapes remain usable without new fields.
     # Catches: Requiring producer pins on public providers created before this feature.
     def test_legacy_bundle_without_producer_fields_reports_missing_pins(self):
-        metadata = self.read_metadata("sample/selected_toolchain_test_legacy_library.selected_toolchain.json")
+        metadata = self.read_metadata("legacy")
 
         self.assertIsNone(metadata["xls_pin"])
         self.assertIsNone(metadata["xlsynth_crate_pin"])
@@ -87,7 +90,7 @@ class SelectedToolchainExportsTest(unittest.TestCase):
     # Verifies: Externally supplied producer structs are normalized before export.
     # Catches: Raw release or Git inputs bypassing the canonical producer parser.
     def test_external_bundle_producer_fields_are_canonicalized(self):
-        metadata = self.read_metadata("sample/selected_toolchain_test_external_library.selected_toolchain.json")
+        metadata = self.read_metadata("external")
 
         self.assertEqual(metadata["xls_pin"], {"kind": "release_tag", "value": "v0.40.0"})
         self.assertEqual(
@@ -98,10 +101,18 @@ class SelectedToolchainExportsTest(unittest.TestCase):
     # Verifies: One available producer survives when the other producer is unknown.
     # Catches: Treating independently unavailable producer identities as all-or-nothing.
     def test_partial_bundle_preserves_independently_missing_pin(self):
-        metadata = self.read_metadata("sample/selected_toolchain_test_partial_library.selected_toolchain.json")
+        metadata = self.read_metadata("partial")
 
         self.assertEqual(metadata["xls_pin"], {"kind": "release_tag", "value": "v0.40.0"})
         self.assertIsNone(metadata["xlsynth_crate_pin"])
+
+    # Verifies: Known XLSynth metadata remains available without XLS metadata.
+    # Catches: Making the two producer fields interdependent during JSON export.
+    def test_partial_bundle_preserves_known_driver_when_xls_is_missing(self):
+        metadata = self.read_metadata("partial_driver")
+
+        self.assertIsNone(metadata["xls_pin"])
+        self.assertEqual(metadata["xlsynth_crate_pin"], {"kind": "release_tag", "value": "v0.36.0"})
 
 
 if __name__ == "__main__":

--- a/selected_toolchain_exports_test.py
+++ b/selected_toolchain_exports_test.py
@@ -24,9 +24,14 @@ class SelectedToolchainExportsTest(unittest.TestCase):
     def test_default_library_exposes_canonical_independent_producer_pins(self):
         metadata = self.read_metadata("sample/selected_toolchain_test_default_library.selected_toolchain.json")
 
-        self.assertEqual(metadata["schema_version"], 1)
-        self.assertEqual(metadata["xls_pin"], {"kind": "release_tag", "value": "v0.40.0"})
-        self.assertEqual(metadata["xlsynth_crate_pin"], {"kind": "release_tag", "value": "v0.36.0"})
+        self.assertEqual(
+            metadata,
+            {
+                "schema_version": 1,
+                "xls_pin": {"kind": "release_tag", "value": "v0.40.0"},
+                "xlsynth_crate_pin": {"kind": "release_tag", "value": "v0.36.0"},
+            },
+        )
 
     # Verifies: Metadata reflects the producer versions of a library override.
     # Catches: Reporting a repository default for an explicitly overridden target.
@@ -40,13 +45,28 @@ class SelectedToolchainExportsTest(unittest.TestCase):
     # Catches: Emitting a release tag or uppercase revision for a Git toolchain.
     def test_git_revisions_are_distinguished_and_normalized(self):
         metadata = self.read_metadata("sample/selected_toolchain_test_git_library.selected_toolchain.json")
-        expected_pin = {
+        expected_xls_pin = {
             "kind": "git_revision",
             "value": "abcdef0123456789abcdef0123456789abcdef01",
         }
+        expected_driver_pin = {
+            "kind": "git_revision",
+            "value": "1234567890abcdef1234567890abcdef12345678",
+        }
 
-        self.assertEqual(metadata["xls_pin"], expected_pin)
-        self.assertEqual(metadata["xlsynth_crate_pin"], expected_pin)
+        self.assertEqual(metadata["xls_pin"], expected_xls_pin)
+        self.assertEqual(metadata["xlsynth_crate_pin"], expected_driver_pin)
+
+    # Verifies: A release-pinned XLS producer can pair with a Git-pinned driver.
+    # Catches: Conflating independent producer identities or their representations.
+    def test_release_and_git_producer_pins_can_be_mixed(self):
+        metadata = self.read_metadata("sample/selected_toolchain_test_mixed_library.selected_toolchain.json")
+
+        self.assertEqual(metadata["xls_pin"], {"kind": "release_tag", "value": "v0.40.0"})
+        self.assertEqual(
+            metadata["xlsynth_crate_pin"],
+            {"kind": "git_revision", "value": "1234567890abcdef1234567890abcdef12345678"},
+        )
 
     # Verifies: Local versionless toolchains report missing producer pins as null.
     # Catches: Fabricated identity data or rejected local toolchain bundles.

--- a/selected_toolchain_test.bzl
+++ b/selected_toolchain_test.bzl
@@ -3,7 +3,7 @@
 """Analysis coverage for the producer pins selected by DSLX libraries."""
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
-load("//:rules.bzl", "DslxSelectedToolchainInfo")
+load("//:rules.bzl", "DslxSelectedToolchainInfo", "dslx_library")
 load("//:xls_toolchain.bzl", "XlsArtifactBundleInfo", "xls_bundle")
 
 _UPPERCASE_GIT_REVISION = "ABCDEF0123456789ABCDEF0123456789ABCDEF01"
@@ -15,12 +15,15 @@ def _selected_toolchain_test_impl(ctx):
     target = analysistest.target_under_test(env)
     selected = target[DslxSelectedToolchainInfo]
 
-    if ctx.attr.expect_missing:
+    if ctx.attr.expect_missing or ctx.attr.expect_missing_xls:
         asserts.equals(env, None, selected.xls_pin)
-        asserts.equals(env, None, selected.xlsynth_crate_pin)
     else:
         asserts.equals(env, ctx.attr.expected_xls_kind, selected.xls_pin.kind)
         asserts.equals(env, ctx.attr.expected_xls_value, selected.xls_pin.value)
+
+    if ctx.attr.expect_missing or ctx.attr.expect_missing_driver:
+        asserts.equals(env, None, selected.xlsynth_crate_pin)
+    else:
         asserts.equals(env, ctx.attr.expected_driver_kind, selected.xlsynth_crate_pin.kind)
         asserts.equals(env, ctx.attr.expected_driver_value, selected.xlsynth_crate_pin.value)
 
@@ -34,14 +37,28 @@ def _selected_toolchain_test_impl(ctx):
     asserts.equals(env, metadata_outputs[0], selected.metadata)
     return analysistest.end(env)
 
+_SELECTED_TOOLCHAIN_TEST_ATTRS = {
+    "expect_missing": attr.bool(),
+    "expect_missing_driver": attr.bool(),
+    "expect_missing_xls": attr.bool(),
+    "expected_driver_kind": attr.string(),
+    "expected_driver_value": attr.string(),
+    "expected_xls_kind": attr.string(),
+    "expected_xls_value": attr.string(),
+}
+
 _selected_toolchain_test = analysistest.make(
     _selected_toolchain_test_impl,
-    attrs = {
-        "expect_missing": attr.bool(),
-        "expected_driver_kind": attr.string(),
-        "expected_driver_value": attr.string(),
-        "expected_xls_kind": attr.string(),
-        "expected_xls_value": attr.string(),
+    attrs = _SELECTED_TOOLCHAIN_TEST_ATTRS,
+)
+
+_custom_registered_toolchain_test = analysistest.make(
+    _selected_toolchain_test_impl,
+    attrs = _SELECTED_TOOLCHAIN_TEST_ATTRS,
+    config_settings = {
+        "//command_line_option:extra_toolchains": [
+            "//selected_toolchain_tests:selected_toolchain_test_registered_toolchain",
+        ],
     },
 )
 
@@ -63,7 +80,7 @@ def _fake_bundle(name, **kwargs):
     """Creates an analysis-only bundle without materializing a second toolchain."""
     xls_bundle(
         name = name,
-        driver = "//:LICENSE",
+        driver = ":BUILD.bazel",
         runtime = "@rules_xlsynth_selftest_xls_runtime//:runtime",
         visibility = ["//sample:__pkg__"],
         **kwargs
@@ -108,6 +125,74 @@ _legacy_bundle = rule(
         "xlsynth_pin_value": attr.string(),
     },
 )
+
+def _custom_registered_toolchain_impl(ctx):
+    """Creates external registered metadata without bundle-ingress normalization."""
+    bundle = ctx.attr.bundle[XlsArtifactBundleInfo]
+    fields = {field: getattr(bundle, field) for field in dir(bundle)}
+    fields.update({
+        "add_invariant_assertions": "",
+        "assert_format": "",
+        "disable_warnings": [],
+        "driver_path": bundle.driver.path,
+        "dslx_path": [],
+        "enable_warnings": [],
+        "gate_format": "",
+        "use_system_verilog": "",
+    })
+    fields["xls_pin"] = struct(kind = "release_tag", value = "0.40.0")
+    fields["xlsynth_crate_pin"] = struct(
+        kind = "git_revision",
+        value = _OTHER_UPPERCASE_GIT_REVISION,
+    )
+    return [platform_common.ToolchainInfo(**fields)]
+
+_custom_registered_toolchain = rule(
+    implementation = _custom_registered_toolchain_impl,
+    attrs = {
+        "bundle": attr.label(
+            mandatory = True,
+            providers = [XlsArtifactBundleInfo],
+        ),
+    },
+)
+
+def selected_toolchain_test_fixtures(name):
+    """Owns DSLX fixture declarations and their opt-in metadata inventory."""
+    suffixes = [
+        "default",
+        "override",
+        "git",
+        "mixed",
+        "unpinned",
+        "legacy",
+        "external",
+        "partial",
+        "invalid_external",
+    ]
+    metadata_sources = []
+    for suffix in suffixes:
+        library_name = name + "_" + suffix + "_library"
+        attributes = {
+            "name": library_name,
+            "srcs": ["sample.x"],
+            "tags": ["manual"],
+            "visibility": ["//:__pkg__", "//selected_toolchain_tests:__pkg__"],
+            "deps": [":imported"],
+        }
+        if suffix != "default":
+            attributes["xls_bundle"] = "//selected_toolchain_tests:" + name + "_" + suffix + "_bundle"
+        dslx_library(**attributes)
+        if suffix != "invalid_external":
+            metadata_sources.append(":" + library_name)
+
+    native.filegroup(
+        name = name + "_metadata",
+        srcs = metadata_sources,
+        output_group = "selected_toolchain",
+        tags = ["manual"],
+        visibility = ["//:__pkg__"],
+    )
 
 def selected_toolchain_test_suite(name):
     """Instantiates default, overridden, typed-pin, and failure analysis tests."""
@@ -232,6 +317,50 @@ def selected_toolchain_test_suite(name):
         expected_driver_value = _OTHER_UPPERCASE_GIT_REVISION.lower(),
     )
 
+    partial_bundle = name + "_partial_bundle"
+    _legacy_bundle(
+        name = partial_bundle,
+        bundle = ":" + unpinned_bundle,
+        visibility = ["//sample:__pkg__"],
+        xls_pin_kind = "release_tag",
+        xls_pin_value = "0.40.0",
+    )
+    partial_test = name + "_partial"
+
+    # Verifies: Independently unavailable producer information remains explicit.
+    # Catches: Collapsing a valid XLS pin when the XLSynth pin is unavailable.
+    _selected_toolchain_test(
+        name = partial_test,
+        target_under_test = "//sample:" + name + "_partial_library",
+        expected_xls_kind = "release_tag",
+        expected_xls_value = "v0.40.0",
+        expect_missing_driver = True,
+    )
+
+    registered_impl = name + "_registered_impl"
+    _custom_registered_toolchain(
+        name = registered_impl,
+        bundle = "@rules_xlsynth_selftest_xls_toolchain//:bundle",
+    )
+    native.toolchain(
+        name = name + "_registered_toolchain",
+        toolchain = ":" + registered_impl,
+        toolchain_type = "//:toolchain_type",
+        visibility = ["//visibility:public"],
+    )
+    registered_test = name + "_registered"
+
+    # Verifies: Custom registered ToolchainInfo metadata is normalized at use.
+    # Catches: Assuming every registered toolchain passed through xls_bundle.
+    _custom_registered_toolchain_test(
+        name = registered_test,
+        target_under_test = "//sample:" + name + "_default_library",
+        expected_xls_kind = "release_tag",
+        expected_xls_value = "v0.40.0",
+        expected_driver_kind = "git_revision",
+        expected_driver_value = _OTHER_UPPERCASE_GIT_REVISION.lower(),
+    )
+
     invalid_external_bundle = name + "_invalid_external_bundle"
     _legacy_bundle(
         name = invalid_external_bundle,
@@ -336,6 +465,8 @@ def selected_toolchain_test_suite(name):
             ":" + unpinned_test,
             ":" + legacy_test,
             ":" + external_test,
+            ":" + partial_test,
+            ":" + registered_test,
             ":" + invalid_external_test,
             ":" + invalid_release_test,
             ":" + invalid_xls_release_test,

--- a/selected_toolchain_test.bzl
+++ b/selected_toolchain_test.bzl
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Analysis coverage for the producer pins selected by DSLX libraries."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("//:rules.bzl", "DslxSelectedToolchainInfo")
+load("//:xls_toolchain.bzl", "xls_bundle")
+
+_UPPERCASE_GIT_REVISION = "ABCDEF0123456789ABCDEF0123456789ABCDEF01"
+
+def _selected_toolchain_test_impl(ctx):
+    """Checks selected producer pins and preserves default-versus-opt-in outputs."""
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+    selected = target[DslxSelectedToolchainInfo]
+
+    if ctx.attr.expect_missing:
+        asserts.equals(env, None, selected.xls_pin)
+        asserts.equals(env, None, selected.xlsynth_crate_pin)
+    else:
+        asserts.equals(env, ctx.attr.expected_xls_kind, selected.xls_pin.kind)
+        asserts.equals(env, ctx.attr.expected_xls_value, selected.xls_pin.value)
+        asserts.equals(env, ctx.attr.expected_driver_kind, selected.xlsynth_crate_pin.kind)
+        asserts.equals(env, ctx.attr.expected_driver_value, selected.xlsynth_crate_pin.value)
+
+    default_outputs = target[DefaultInfo].files.to_list()
+    asserts.equals(env, 1, len(default_outputs))
+    asserts.true(env, default_outputs[0].basename.endswith(".typecheck"))
+
+    metadata_outputs = target[OutputGroupInfo].selected_toolchain.to_list()
+    asserts.equals(env, 1, len(metadata_outputs))
+    asserts.true(env, metadata_outputs[0].basename.endswith(".selected_toolchain.json"))
+    asserts.equals(env, metadata_outputs[0], selected.metadata)
+    return analysistest.end(env)
+
+_selected_toolchain_test = analysistest.make(
+    _selected_toolchain_test_impl,
+    attrs = {
+        "expect_missing": attr.bool(),
+        "expected_driver_kind": attr.string(),
+        "expected_driver_value": attr.string(),
+        "expected_xls_kind": attr.string(),
+        "expected_xls_value": attr.string(),
+    },
+)
+
+def _invalid_pin_test_impl(ctx):
+    """Checks that malformed or ambiguous producer pins fail during analysis."""
+    env = analysistest.begin(ctx)
+    asserts.expect_failure(env, ctx.attr.expected_error)
+    return analysistest.end(env)
+
+_invalid_pin_test = analysistest.make(
+    _invalid_pin_test_impl,
+    attrs = {
+        "expected_error": attr.string(mandatory = True),
+    },
+    expect_failure = True,
+)
+
+def _fake_bundle(name, **kwargs):
+    """Creates an analysis-only bundle without materializing a second toolchain."""
+    xls_bundle(
+        name = name,
+        driver = "//:LICENSE",
+        runtime = "@rules_xlsynth_selftest_xls_runtime//:runtime",
+        visibility = ["//sample:__pkg__"],
+        **kwargs
+    )
+
+def selected_toolchain_test_suite(name):
+    """Instantiates default, overridden, typed-pin, and failure analysis tests."""
+    default_test = name + "_default"
+
+    # Verifies: The registered default exposes independent canonical producer pins.
+    # Catches: Incorrect default selection or changed normal library outputs.
+    _selected_toolchain_test(
+        name = default_test,
+        target_under_test = "//sample:" + name + "_default_library",
+        expected_xls_kind = "release_tag",
+        expected_xls_value = "v0.40.0",
+        expected_driver_kind = "release_tag",
+        expected_driver_value = "v0.36.0",
+    )
+
+    override_bundle = name + "_override_bundle"
+    _fake_bundle(
+        name = override_bundle,
+        xls_version = "0.37.0",
+        xlsynth_driver_version = "0.32.0",
+    )
+    override_test = name + "_override"
+
+    # Verifies: A library override exposes its own XLS and XLSynth versions.
+    # Catches: Substituting the registered default for the target's selected bundle.
+    _selected_toolchain_test(
+        name = override_test,
+        target_under_test = "//sample:" + name + "_override_library",
+        expected_xls_kind = "release_tag",
+        expected_xls_value = "v0.37.0",
+        expected_driver_kind = "release_tag",
+        expected_driver_value = "v0.32.0",
+    )
+
+    git_bundle = name + "_git_bundle"
+    _fake_bundle(
+        name = git_bundle,
+        xls_git_revision = _UPPERCASE_GIT_REVISION,
+        xlsynth_driver_git_revision = _UPPERCASE_GIT_REVISION,
+    )
+    git_test = name + "_git"
+
+    # Verifies: Exact Git producer revisions are normalized to lowercase.
+    # Catches: Ambiguous or noncanonical selected-toolchain producer identities.
+    _selected_toolchain_test(
+        name = git_test,
+        target_under_test = "//sample:" + name + "_git_library",
+        expected_xls_kind = "git_revision",
+        expected_xls_value = _UPPERCASE_GIT_REVISION.lower(),
+        expected_driver_kind = "git_revision",
+        expected_driver_value = _UPPERCASE_GIT_REVISION.lower(),
+    )
+
+    unpinned_bundle = name + "_unpinned_bundle"
+    _fake_bundle(name = unpinned_bundle)
+    unpinned_test = name + "_unpinned"
+
+    # Verifies: Versionless local bundles explicitly expose unavailable pins.
+    # Catches: Breaking existing locally configured toolchains during analysis.
+    _selected_toolchain_test(
+        name = unpinned_test,
+        target_under_test = "//sample:" + name + "_unpinned_library",
+        expect_missing = True,
+    )
+
+    invalid_release_bundle = name + "_invalid_release_bundle"
+    _fake_bundle(
+        name = invalid_release_bundle,
+        tags = ["manual"],
+        xls_version = "invalid/release",
+    )
+    invalid_release_test = name + "_invalid_release"
+
+    # Negative test: Invalid release tags exercise producer-pin error handling.
+    _invalid_pin_test(
+        name = invalid_release_test,
+        target_under_test = ":" + invalid_release_bundle,
+        expected_error = "Expected release tag",
+    )
+
+    invalid_revision_bundle = name + "_invalid_revision_bundle"
+    _fake_bundle(
+        name = invalid_revision_bundle,
+        tags = ["manual"],
+        xls_git_revision = "not-an-exact-git-revision",
+    )
+    invalid_revision_test = name + "_invalid_revision"
+
+    # Negative test: Inexact Git revisions exercise producer-pin error handling.
+    _invalid_pin_test(
+        name = invalid_revision_test,
+        target_under_test = ":" + invalid_revision_bundle,
+        expected_error = "Expected exact 40-character Git revision",
+    )
+
+    ambiguous_bundle = name + "_ambiguous_bundle"
+    _fake_bundle(
+        name = ambiguous_bundle,
+        tags = ["manual"],
+        xls_version = "0.40.0",
+        xls_git_revision = _UPPERCASE_GIT_REVISION,
+    )
+    ambiguous_test = name + "_ambiguous"
+
+    # Negative test: Conflicting pin representations exercise error handling.
+    _invalid_pin_test(
+        name = ambiguous_test,
+        target_under_test = ":" + ambiguous_bundle,
+        expected_error = "either a release tag or a Git revision, not both",
+    )
+
+    native.test_suite(
+        name = name,
+        tests = [
+            ":" + default_test,
+            ":" + override_test,
+            ":" + git_test,
+            ":" + unpinned_test,
+            ":" + invalid_release_test,
+            ":" + invalid_revision_test,
+            ":" + ambiguous_test,
+        ],
+    )

--- a/selected_toolchain_test.bzl
+++ b/selected_toolchain_test.bzl
@@ -62,6 +62,16 @@ _custom_registered_toolchain_test = analysistest.make(
     },
 )
 
+_legacy_registered_toolchain_test = analysistest.make(
+    _selected_toolchain_test_impl,
+    attrs = _SELECTED_TOOLCHAIN_TEST_ATTRS,
+    config_settings = {
+        "//command_line_option:extra_toolchains": [
+            "//selected_toolchain_tests:selected_toolchain_test_legacy_registered_toolchain",
+        ],
+    },
+)
+
 def _invalid_pin_test_impl(ctx):
     """Checks that malformed or ambiguous producer pins fail during analysis."""
     env = analysistest.begin(ctx)
@@ -82,7 +92,6 @@ def _fake_bundle(name, **kwargs):
         name = name,
         driver = ":BUILD.bazel",
         runtime = "@rules_xlsynth_selftest_xls_runtime//:runtime",
-        visibility = ["//sample:__pkg__"],
         **kwargs
     )
 
@@ -140,11 +149,15 @@ def _custom_registered_toolchain_impl(ctx):
         "gate_format": "",
         "use_system_verilog": "",
     })
-    fields["xls_pin"] = struct(kind = "release_tag", value = "0.40.0")
-    fields["xlsynth_crate_pin"] = struct(
-        kind = "git_revision",
-        value = _OTHER_UPPERCASE_GIT_REVISION,
-    )
+    if ctx.attr.include_producers:
+        fields["xls_pin"] = struct(kind = "release_tag", value = "0.40.0")
+        fields["xlsynth_crate_pin"] = struct(
+            kind = "git_revision",
+            value = _OTHER_UPPERCASE_GIT_REVISION,
+        )
+    else:
+        fields.pop("xls_pin")
+        fields.pop("xlsynth_crate_pin")
     return [platform_common.ToolchainInfo(**fields)]
 
 _custom_registered_toolchain = rule(
@@ -154,6 +167,7 @@ _custom_registered_toolchain = rule(
             mandatory = True,
             providers = [XlsArtifactBundleInfo],
         ),
+        "include_producers": attr.bool(default = True),
     },
 )
 
@@ -168,6 +182,7 @@ def selected_toolchain_test_fixtures(name):
         "legacy",
         "external",
         "partial",
+        "partial_driver",
         "invalid_external",
     ]
     metadata_sources = []
@@ -175,13 +190,11 @@ def selected_toolchain_test_fixtures(name):
         library_name = name + "_" + suffix + "_library"
         attributes = {
             "name": library_name,
-            "srcs": ["sample.x"],
+            "srcs": ["//sample:imported.x"],
             "tags": ["manual"],
-            "visibility": ["//:__pkg__", "//selected_toolchain_tests:__pkg__"],
-            "deps": [":imported"],
         }
         if suffix != "default":
-            attributes["xls_bundle"] = "//selected_toolchain_tests:" + name + "_" + suffix + "_bundle"
+            attributes["xls_bundle"] = ":" + name + "_" + suffix + "_bundle"
         dslx_library(**attributes)
         if suffix != "invalid_external":
             metadata_sources.append(":" + library_name)
@@ -202,7 +215,7 @@ def selected_toolchain_test_suite(name):
     # Catches: Incorrect default selection or changed normal library outputs.
     _selected_toolchain_test(
         name = default_test,
-        target_under_test = "//sample:" + name + "_default_library",
+        target_under_test = ":" + name + "_default_library",
         expected_xls_kind = "release_tag",
         expected_xls_value = "v0.40.0",
         expected_driver_kind = "release_tag",
@@ -221,7 +234,7 @@ def selected_toolchain_test_suite(name):
     # Catches: Substituting the registered default for the target's selected bundle.
     _selected_toolchain_test(
         name = override_test,
-        target_under_test = "//sample:" + name + "_override_library",
+        target_under_test = ":" + name + "_override_library",
         expected_xls_kind = "release_tag",
         expected_xls_value = "v0.37.0",
         expected_driver_kind = "release_tag",
@@ -240,7 +253,7 @@ def selected_toolchain_test_suite(name):
     # Catches: Swapped, copied, or noncanonical XLS/XLSynth producer identities.
     _selected_toolchain_test(
         name = git_test,
-        target_under_test = "//sample:" + name + "_git_library",
+        target_under_test = ":" + name + "_git_library",
         expected_xls_kind = "git_revision",
         expected_xls_value = _UPPERCASE_GIT_REVISION.lower(),
         expected_driver_kind = "git_revision",
@@ -259,7 +272,7 @@ def selected_toolchain_test_suite(name):
     # Catches: Assuming both configured producers must share one identity kind.
     _selected_toolchain_test(
         name = mixed_test,
-        target_under_test = "//sample:" + name + "_mixed_library",
+        target_under_test = ":" + name + "_mixed_library",
         expected_xls_kind = "release_tag",
         expected_xls_value = "v0.40.0",
         expected_driver_kind = "git_revision",
@@ -274,7 +287,7 @@ def selected_toolchain_test_suite(name):
     # Catches: Breaking existing locally configured toolchains during analysis.
     _selected_toolchain_test(
         name = unpinned_test,
-        target_under_test = "//sample:" + name + "_unpinned_library",
+        target_under_test = ":" + name + "_unpinned_library",
         expect_missing = True,
     )
 
@@ -282,7 +295,6 @@ def selected_toolchain_test_suite(name):
     _legacy_bundle(
         name = legacy_bundle,
         bundle = ":" + unpinned_bundle,
-        visibility = ["//sample:__pkg__"],
     )
     legacy_test = name + "_legacy"
 
@@ -290,7 +302,7 @@ def selected_toolchain_test_suite(name):
     # Catches: Treating newly introduced optional producer fields as mandatory.
     _selected_toolchain_test(
         name = legacy_test,
-        target_under_test = "//sample:" + name + "_legacy_library",
+        target_under_test = ":" + name + "_legacy_library",
         expect_missing = True,
     )
 
@@ -298,7 +310,6 @@ def selected_toolchain_test_suite(name):
     _legacy_bundle(
         name = external_bundle,
         bundle = ":" + unpinned_bundle,
-        visibility = ["//sample:__pkg__"],
         xls_pin_kind = "release_tag",
         xls_pin_value = "0.40.0",
         xlsynth_pin_kind = "git_revision",
@@ -310,7 +321,7 @@ def selected_toolchain_test_suite(name):
     # Catches: Unprefixed releases or uppercase Git revisions leaking into metadata.
     _selected_toolchain_test(
         name = external_test,
-        target_under_test = "//sample:" + name + "_external_library",
+        target_under_test = ":" + name + "_external_library",
         expected_xls_kind = "release_tag",
         expected_xls_value = "v0.40.0",
         expected_driver_kind = "git_revision",
@@ -321,7 +332,6 @@ def selected_toolchain_test_suite(name):
     _legacy_bundle(
         name = partial_bundle,
         bundle = ":" + unpinned_bundle,
-        visibility = ["//sample:__pkg__"],
         xls_pin_kind = "release_tag",
         xls_pin_value = "0.40.0",
     )
@@ -331,10 +341,29 @@ def selected_toolchain_test_suite(name):
     # Catches: Collapsing a valid XLS pin when the XLSynth pin is unavailable.
     _selected_toolchain_test(
         name = partial_test,
-        target_under_test = "//sample:" + name + "_partial_library",
+        target_under_test = ":" + name + "_partial_library",
         expected_xls_kind = "release_tag",
         expected_xls_value = "v0.40.0",
         expect_missing_driver = True,
+    )
+
+    partial_driver_bundle = name + "_partial_driver_bundle"
+    _legacy_bundle(
+        name = partial_driver_bundle,
+        bundle = ":" + unpinned_bundle,
+        xlsynth_pin_kind = "release_tag",
+        xlsynth_pin_value = "0.36.0",
+    )
+    partial_driver_test = name + "_partial_driver"
+
+    # Verifies: A known XLSynth producer survives unavailable XLS metadata.
+    # Catches: Treating producer availability as dependent on the XLS pin.
+    _selected_toolchain_test(
+        name = partial_driver_test,
+        target_under_test = ":" + name + "_partial_driver_library",
+        expect_missing_xls = True,
+        expected_driver_kind = "release_tag",
+        expected_driver_value = "v0.36.0",
     )
 
     registered_impl = name + "_registered_impl"
@@ -354,11 +383,33 @@ def selected_toolchain_test_suite(name):
     # Catches: Assuming every registered toolchain passed through xls_bundle.
     _custom_registered_toolchain_test(
         name = registered_test,
-        target_under_test = "//sample:" + name + "_default_library",
+        target_under_test = ":" + name + "_default_library",
         expected_xls_kind = "release_tag",
         expected_xls_value = "v0.40.0",
         expected_driver_kind = "git_revision",
         expected_driver_value = _OTHER_UPPERCASE_GIT_REVISION.lower(),
+    )
+
+    legacy_registered_impl = name + "_legacy_registered_impl"
+    _custom_registered_toolchain(
+        name = legacy_registered_impl,
+        bundle = "@rules_xlsynth_selftest_xls_toolchain//:bundle",
+        include_producers = False,
+    )
+    native.toolchain(
+        name = name + "_legacy_registered_toolchain",
+        toolchain = ":" + legacy_registered_impl,
+        toolchain_type = "//:toolchain_type",
+        visibility = ["//visibility:public"],
+    )
+    legacy_registered_test = name + "_legacy_registered"
+
+    # Verifies: Legacy directly registered toolchains need no producer fields.
+    # Catches: Assuming every ToolchainInfo carries newly introduced metadata.
+    _legacy_registered_toolchain_test(
+        name = legacy_registered_test,
+        target_under_test = ":" + name + "_default_library",
+        expect_missing = True,
     )
 
     invalid_external_bundle = name + "_invalid_external_bundle"
@@ -366,7 +417,6 @@ def selected_toolchain_test_suite(name):
         name = invalid_external_bundle,
         bundle = ":" + unpinned_bundle,
         tags = ["manual"],
-        visibility = ["//sample:__pkg__"],
         xls_pin_kind = "git_revision",
         xls_pin_value = "ABC",
     )
@@ -375,7 +425,7 @@ def selected_toolchain_test_suite(name):
     # Negative test: Invalid external Git pins fail at the bundle ingress boundary.
     _invalid_pin_test(
         name = invalid_external_test,
-        target_under_test = "//sample:" + name + "_invalid_external_library",
+        target_under_test = ":" + name + "_invalid_external_library",
         expected_error = "Expected exact 40-character Git revision",
     )
 
@@ -466,7 +516,9 @@ def selected_toolchain_test_suite(name):
             ":" + legacy_test,
             ":" + external_test,
             ":" + partial_test,
+            ":" + partial_driver_test,
             ":" + registered_test,
+            ":" + legacy_registered_test,
             ":" + invalid_external_test,
             ":" + invalid_release_test,
             ":" + invalid_xls_release_test,

--- a/selected_toolchain_test.bzl
+++ b/selected_toolchain_test.bzl
@@ -196,7 +196,7 @@ def selected_toolchain_test_fixtures(name):
         if suffix != "default":
             attributes["xls_bundle"] = ":" + name + "_" + suffix + "_bundle"
         dslx_library(**attributes)
-        if suffix != "invalid_external":
+        if suffix in ["default", "override", "git", "mixed", "unpinned", "partial"]:
             metadata_sources.append(":" + library_name)
 
     native.filegroup(

--- a/selected_toolchain_test.bzl
+++ b/selected_toolchain_test.bzl
@@ -70,23 +70,31 @@ def _fake_bundle(name, **kwargs):
     )
 
 def _legacy_bundle_impl(ctx):
-    """Preserves the public bundle shape used before producer pins existed."""
+    """Constructs external public bundles with optional raw producer metadata."""
     bundle = ctx.attr.bundle[XlsArtifactBundleInfo]
+    fields = {
+        "artifact_inputs": bundle.artifact_inputs,
+        "driver": bundle.driver,
+        "driver_supports_sv_enum_case_naming_policy": bundle.driver_supports_sv_enum_case_naming_policy,
+        "driver_supports_sv_struct_field_ordering": bundle.driver_supports_sv_struct_field_ordering,
+        "dslx_stdlib": bundle.dslx_stdlib,
+        "dslx_stdlib_path": bundle.dslx_stdlib_path,
+        "libxls": bundle.libxls,
+        "runtime_files": bundle.runtime_files,
+        "runtime_library_path": bundle.runtime_library_path,
+        "resolved_identity": bundle.resolved_identity,
+        "tools_root": bundle.tools_root,
+        "tools_path": bundle.tools_path,
+    }
+    if ctx.attr.xls_pin_kind:
+        fields["xls_pin"] = struct(kind = ctx.attr.xls_pin_kind, value = ctx.attr.xls_pin_value)
+    if ctx.attr.xlsynth_pin_kind:
+        fields["xlsynth_crate_pin"] = struct(
+            kind = ctx.attr.xlsynth_pin_kind,
+            value = ctx.attr.xlsynth_pin_value,
+        )
     return [
-        XlsArtifactBundleInfo(
-            artifact_inputs = bundle.artifact_inputs,
-            driver = bundle.driver,
-            driver_supports_sv_enum_case_naming_policy = bundle.driver_supports_sv_enum_case_naming_policy,
-            driver_supports_sv_struct_field_ordering = bundle.driver_supports_sv_struct_field_ordering,
-            dslx_stdlib = bundle.dslx_stdlib,
-            dslx_stdlib_path = bundle.dslx_stdlib_path,
-            libxls = bundle.libxls,
-            runtime_files = bundle.runtime_files,
-            runtime_library_path = bundle.runtime_library_path,
-            resolved_identity = bundle.resolved_identity,
-            tools_root = bundle.tools_root,
-            tools_path = bundle.tools_path,
-        ),
+        XlsArtifactBundleInfo(**fields),
         DefaultInfo(files = ctx.attr.bundle[DefaultInfo].files),
     ]
 
@@ -94,6 +102,10 @@ _legacy_bundle = rule(
     implementation = _legacy_bundle_impl,
     attrs = {
         "bundle": attr.label(mandatory = True, providers = [XlsArtifactBundleInfo]),
+        "xls_pin_kind": attr.string(),
+        "xls_pin_value": attr.string(),
+        "xlsynth_pin_kind": attr.string(),
+        "xlsynth_pin_value": attr.string(),
     },
 )
 
@@ -197,6 +209,47 @@ def selected_toolchain_test_suite(name):
         expect_missing = True,
     )
 
+    external_bundle = name + "_external_bundle"
+    _legacy_bundle(
+        name = external_bundle,
+        bundle = ":" + unpinned_bundle,
+        visibility = ["//sample:__pkg__"],
+        xls_pin_kind = "release_tag",
+        xls_pin_value = "0.40.0",
+        xlsynth_pin_kind = "git_revision",
+        xlsynth_pin_value = _OTHER_UPPERCASE_GIT_REVISION,
+    )
+    external_test = name + "_external"
+
+    # Verifies: External provider pins use the existing canonical producer parser.
+    # Catches: Unprefixed releases or uppercase Git revisions leaking into metadata.
+    _selected_toolchain_test(
+        name = external_test,
+        target_under_test = "//sample:" + name + "_external_library",
+        expected_xls_kind = "release_tag",
+        expected_xls_value = "v0.40.0",
+        expected_driver_kind = "git_revision",
+        expected_driver_value = _OTHER_UPPERCASE_GIT_REVISION.lower(),
+    )
+
+    invalid_external_bundle = name + "_invalid_external_bundle"
+    _legacy_bundle(
+        name = invalid_external_bundle,
+        bundle = ":" + unpinned_bundle,
+        tags = ["manual"],
+        visibility = ["//sample:__pkg__"],
+        xls_pin_kind = "git_revision",
+        xls_pin_value = "ABC",
+    )
+    invalid_external_test = name + "_invalid_external"
+
+    # Negative test: Invalid external Git pins fail at the bundle ingress boundary.
+    _invalid_pin_test(
+        name = invalid_external_test,
+        target_under_test = "//sample:" + name + "_invalid_external_library",
+        expected_error = "Expected exact 40-character Git revision",
+    )
+
     invalid_release_bundle = name + "_invalid_release_bundle"
     _fake_bundle(
         name = invalid_release_bundle,
@@ -282,6 +335,8 @@ def selected_toolchain_test_suite(name):
             ":" + mixed_test,
             ":" + unpinned_test,
             ":" + legacy_test,
+            ":" + external_test,
+            ":" + invalid_external_test,
             ":" + invalid_release_test,
             ":" + invalid_xls_release_test,
             ":" + invalid_revision_test,

--- a/selected_toolchain_test.bzl
+++ b/selected_toolchain_test.bzl
@@ -4,7 +4,7 @@
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("//:rules.bzl", "DslxSelectedToolchainInfo")
-load("//:xls_toolchain.bzl", "xls_bundle")
+load("//:xls_toolchain.bzl", "XlsArtifactBundleInfo", "xls_bundle")
 
 _UPPERCASE_GIT_REVISION = "ABCDEF0123456789ABCDEF0123456789ABCDEF01"
 _OTHER_UPPERCASE_GIT_REVISION = "1234567890ABCDEF1234567890ABCDEF12345678"
@@ -68,6 +68,34 @@ def _fake_bundle(name, **kwargs):
         visibility = ["//sample:__pkg__"],
         **kwargs
     )
+
+def _legacy_bundle_impl(ctx):
+    """Preserves the public bundle shape used before producer pins existed."""
+    bundle = ctx.attr.bundle[XlsArtifactBundleInfo]
+    return [
+        XlsArtifactBundleInfo(
+            artifact_inputs = bundle.artifact_inputs,
+            driver = bundle.driver,
+            driver_supports_sv_enum_case_naming_policy = bundle.driver_supports_sv_enum_case_naming_policy,
+            driver_supports_sv_struct_field_ordering = bundle.driver_supports_sv_struct_field_ordering,
+            dslx_stdlib = bundle.dslx_stdlib,
+            dslx_stdlib_path = bundle.dslx_stdlib_path,
+            libxls = bundle.libxls,
+            runtime_files = bundle.runtime_files,
+            runtime_library_path = bundle.runtime_library_path,
+            resolved_identity = bundle.resolved_identity,
+            tools_root = bundle.tools_root,
+            tools_path = bundle.tools_path,
+        ),
+        DefaultInfo(files = ctx.attr.bundle[DefaultInfo].files),
+    ]
+
+_legacy_bundle = rule(
+    implementation = _legacy_bundle_impl,
+    attrs = {
+        "bundle": attr.label(mandatory = True, providers = [XlsArtifactBundleInfo]),
+    },
+)
 
 def selected_toolchain_test_suite(name):
     """Instantiates default, overridden, typed-pin, and failure analysis tests."""
@@ -150,6 +178,22 @@ def selected_toolchain_test_suite(name):
     _selected_toolchain_test(
         name = unpinned_test,
         target_under_test = "//sample:" + name + "_unpinned_library",
+        expect_missing = True,
+    )
+
+    legacy_bundle = name + "_legacy_bundle"
+    _legacy_bundle(
+        name = legacy_bundle,
+        bundle = ":" + unpinned_bundle,
+        visibility = ["//sample:__pkg__"],
+    )
+    legacy_test = name + "_legacy"
+
+    # Verifies: Older externally constructed bundles remain valid overrides.
+    # Catches: Treating newly introduced optional producer fields as mandatory.
+    _selected_toolchain_test(
+        name = legacy_test,
+        target_under_test = "//sample:" + name + "_legacy_library",
         expect_missing = True,
     )
 
@@ -237,6 +281,7 @@ def selected_toolchain_test_suite(name):
             ":" + git_test,
             ":" + mixed_test,
             ":" + unpinned_test,
+            ":" + legacy_test,
             ":" + invalid_release_test,
             ":" + invalid_xls_release_test,
             ":" + invalid_revision_test,

--- a/selected_toolchain_test.bzl
+++ b/selected_toolchain_test.bzl
@@ -87,8 +87,8 @@ def selected_toolchain_test_suite(name):
     override_bundle = name + "_override_bundle"
     _fake_bundle(
         name = override_bundle,
-        xls_version = "0.37.0",
-        xlsynth_driver_version = "0.32.0",
+        xls_version = "v0.37.0",
+        xlsynth_driver_version = "v0.32.0",
     )
     override_test = name + "_override"
 

--- a/selected_toolchain_test.bzl
+++ b/selected_toolchain_test.bzl
@@ -7,6 +7,7 @@ load("//:rules.bzl", "DslxSelectedToolchainInfo")
 load("//:xls_toolchain.bzl", "xls_bundle")
 
 _UPPERCASE_GIT_REVISION = "ABCDEF0123456789ABCDEF0123456789ABCDEF01"
+_OTHER_UPPERCASE_GIT_REVISION = "1234567890ABCDEF1234567890ABCDEF12345678"
 
 def _selected_toolchain_test_impl(ctx):
     """Checks selected producer pins and preserves default-versus-opt-in outputs."""
@@ -106,19 +107,38 @@ def selected_toolchain_test_suite(name):
     _fake_bundle(
         name = git_bundle,
         xls_git_revision = _UPPERCASE_GIT_REVISION,
-        xlsynth_driver_git_revision = _UPPERCASE_GIT_REVISION,
+        xlsynth_driver_git_revision = _OTHER_UPPERCASE_GIT_REVISION,
     )
     git_test = name + "_git"
 
-    # Verifies: Exact Git producer revisions are normalized to lowercase.
-    # Catches: Ambiguous or noncanonical selected-toolchain producer identities.
+    # Verifies: Distinct Git producer revisions are normalized independently.
+    # Catches: Swapped, copied, or noncanonical XLS/XLSynth producer identities.
     _selected_toolchain_test(
         name = git_test,
         target_under_test = "//sample:" + name + "_git_library",
         expected_xls_kind = "git_revision",
         expected_xls_value = _UPPERCASE_GIT_REVISION.lower(),
         expected_driver_kind = "git_revision",
-        expected_driver_value = _UPPERCASE_GIT_REVISION.lower(),
+        expected_driver_value = _OTHER_UPPERCASE_GIT_REVISION.lower(),
+    )
+
+    mixed_bundle = name + "_mixed_bundle"
+    _fake_bundle(
+        name = mixed_bundle,
+        xls_version = "0.40.0",
+        xlsynth_driver_git_revision = _OTHER_UPPERCASE_GIT_REVISION,
+    )
+    mixed_test = name + "_mixed"
+
+    # Verifies: XLS release and XLSynth Git producer identities remain independent.
+    # Catches: Assuming both configured producers must share one identity kind.
+    _selected_toolchain_test(
+        name = mixed_test,
+        target_under_test = "//sample:" + name + "_mixed_library",
+        expected_xls_kind = "release_tag",
+        expected_xls_value = "v0.40.0",
+        expected_driver_kind = "git_revision",
+        expected_driver_value = _OTHER_UPPERCASE_GIT_REVISION.lower(),
     )
 
     unpinned_bundle = name + "_unpinned_bundle"
@@ -148,6 +168,21 @@ def selected_toolchain_test_suite(name):
         expected_error = "Expected release tag",
     )
 
+    invalid_xls_release_bundle = name + "_invalid_xls_release_bundle"
+    _fake_bundle(
+        name = invalid_xls_release_bundle,
+        tags = ["manual"],
+        xls_version = "next",
+    )
+    invalid_xls_release_test = name + "_invalid_xls_release"
+
+    # Negative test: Nonsemantic XLS release tags exercise producer error handling.
+    _invalid_pin_test(
+        name = invalid_xls_release_test,
+        target_under_test = ":" + invalid_xls_release_bundle,
+        expected_error = "Expected XLS semantic release tag",
+    )
+
     invalid_revision_bundle = name + "_invalid_revision_bundle"
     _fake_bundle(
         name = invalid_revision_bundle,
@@ -160,6 +195,21 @@ def selected_toolchain_test_suite(name):
     _invalid_pin_test(
         name = invalid_revision_test,
         target_under_test = ":" + invalid_revision_bundle,
+        expected_error = "Expected exact 40-character Git revision",
+    )
+
+    nonhex_revision_bundle = name + "_nonhex_revision_bundle"
+    _fake_bundle(
+        name = nonhex_revision_bundle,
+        tags = ["manual"],
+        xls_git_revision = "G" * 40,
+    )
+    nonhex_revision_test = name + "_nonhex_revision"
+
+    # Negative test: Exact-length nonhex Git revisions exercise error handling.
+    _invalid_pin_test(
+        name = nonhex_revision_test,
+        target_under_test = ":" + nonhex_revision_bundle,
         expected_error = "Expected exact 40-character Git revision",
     )
 
@@ -185,9 +235,12 @@ def selected_toolchain_test_suite(name):
             ":" + default_test,
             ":" + override_test,
             ":" + git_test,
+            ":" + mixed_test,
             ":" + unpinned_test,
             ":" + invalid_release_test,
+            ":" + invalid_xls_release_test,
             ":" + invalid_revision_test,
+            ":" + nonhex_revision_test,
             ":" + ambiguous_test,
         ],
     )

--- a/selected_toolchain_tests/BUILD.bazel
+++ b/selected_toolchain_tests/BUILD.bazel
@@ -1,6 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
-load("//:selected_toolchain_test.bzl", "selected_toolchain_test_suite")
+load(
+    "//:selected_toolchain_test.bzl",
+    "selected_toolchain_test_fixtures",
+    "selected_toolchain_test_suite",
+)
+
+selected_toolchain_test_fixtures(
+    name = "selected_toolchain_test",
+)
 
 selected_toolchain_test_suite(
     name = "selected_toolchain_test",

--- a/selected_toolchain_tests/BUILD.bazel
+++ b/selected_toolchain_tests/BUILD.bazel
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+load("//:selected_toolchain_test.bzl", "selected_toolchain_test_suite")
+
+selected_toolchain_test_suite(
+    name = "selected_toolchain_test",
+)

--- a/xls_toolchain.bzl
+++ b/xls_toolchain.bzl
@@ -68,7 +68,28 @@ def _validate_tri_state(value, label):
         fail("{} must be one of {}".format(label, _TRI_STATE_VALUES))
     return value
 
-def _declared_producer_pin(version, git_revision, label):
+def _validate_xls_release_tag(release_tag):
+    """Rejects XLS release tags outside the existing semantic-release grammar."""
+    release_parts = release_tag[1:].split("-", 1)
+    version_parts = release_parts[0].split(".")
+    valid = len(version_parts) == 3
+    for component in version_parts:
+        if not component:
+            valid = False
+        for index in range(len(component)):
+            if component[index] not in "0123456789":
+                valid = False
+    if len(release_parts) == 2:
+        suffix = release_parts[1]
+        if not suffix:
+            valid = False
+        for index in range(len(suffix)):
+            if suffix[index] not in "0123456789":
+                valid = False
+    if not valid:
+        fail("Expected XLS semantic release tag, got: {}".format(release_tag))
+
+def _declared_producer_pin(version, git_revision, label, require_xls_release = False):
     """Returns a canonical configured producer pin without authenticating artifacts."""
     if version and git_revision:
         fail("{} accepts either a release tag or a Git revision, not both".format(label))
@@ -79,6 +100,8 @@ def _declared_producer_pin(version, git_revision, label):
         for index in range(1, len(normalized)):
             if normalized[index] not in _RELEASE_TAG_CHARACTERS:
                 fail("Expected release tag, got: {}".format(version))
+        if require_xls_release:
+            _validate_xls_release_tag(normalized)
         pin = struct(kind = "release_tag", value = normalized)
     elif git_revision:
         if len(git_revision) != 40:
@@ -466,6 +489,7 @@ def _xls_bundle_impl(ctx):
                 ctx.attr.xls_version,
                 ctx.attr.xls_git_revision,
                 "XLS pin",
+                require_xls_release = True,
             ),
             xlsynth_crate_pin = _declared_producer_pin(
                 ctx.attr.xlsynth_driver_version,

--- a/xls_toolchain.bzl
+++ b/xls_toolchain.bzl
@@ -153,8 +153,8 @@ def _bundle_struct_from_provider(bundle):
         resolved_identity = bundle.resolved_identity,
         tools_root = bundle.tools_root,
         tools_path = bundle.tools_path,
-        xls_pin = bundle.xls_pin,
-        xlsynth_crate_pin = bundle.xlsynth_crate_pin,
+        xls_pin = getattr(bundle, "xls_pin", None),
+        xlsynth_crate_pin = getattr(bundle, "xlsynth_crate_pin", None),
     )
 
 def _runtime_struct_from_provider(runtime):

--- a/xls_toolchain.bzl
+++ b/xls_toolchain.bzl
@@ -6,6 +6,9 @@ load("@rules_cc//cc:defs.bzl", "CcInfo", "cc_common")
 
 _XLS_TOOLCHAIN_TYPE = "//:toolchain_type"
 _TRI_STATE_VALUES = ["", "true", "false"]
+_ALPHANUMERIC_CHARACTERS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+_GIT_REVISION_CHARACTERS = "0123456789abcdefABCDEF"
+_RELEASE_TAG_CHARACTERS = _ALPHANUMERIC_CHARACTERS + ".+-"
 
 XlsArtifactBundleInfo = provider(
     doc = "Versioned or local XLS bundle artifacts materialized by the module extension.",
@@ -22,6 +25,8 @@ XlsArtifactBundleInfo = provider(
         "resolved_identity": "Machine-readable resolved producer identity manifest, when requested.",
         "tools_root": "The XLS tool root tree artifact.",
         "tools_path": "Directory path containing the XLS tool binaries.",
+        "xls_pin": "Declared canonical XLS producer pin, or None when the bundle is unpinned.",
+        "xlsynth_crate_pin": "Declared canonical XLSynth producer pin, or None when the bundle is unpinned.",
     },
 )
 
@@ -63,6 +68,29 @@ def _validate_tri_state(value, label):
         fail("{} must be one of {}".format(label, _TRI_STATE_VALUES))
     return value
 
+def _declared_producer_pin(version, git_revision, label):
+    """Returns a canonical configured producer pin without authenticating artifacts."""
+    if version and git_revision:
+        fail("{} accepts either a release tag or a Git revision, not both".format(label))
+    elif version:
+        normalized = version if version.startswith("v") else "v" + version
+        if len(normalized) < 2 or normalized[1] not in _ALPHANUMERIC_CHARACTERS:
+            fail("Expected release tag, got: {}".format(version))
+        for index in range(1, len(normalized)):
+            if normalized[index] not in _RELEASE_TAG_CHARACTERS:
+                fail("Expected release tag, got: {}".format(version))
+        pin = struct(kind = "release_tag", value = normalized)
+    elif git_revision:
+        if len(git_revision) != 40:
+            fail("Expected exact 40-character Git revision, got: {}".format(git_revision))
+        for index in range(len(git_revision)):
+            if git_revision[index] not in _GIT_REVISION_CHARACTERS:
+                fail("Expected exact 40-character Git revision, got: {}".format(git_revision))
+        pin = struct(kind = "git_revision", value = git_revision.lower())
+    else:
+        pin = None
+    return pin
+
 def _single_artifact(target, label):
     files = target[DefaultInfo].files.to_list()
     if len(files) != 1:
@@ -102,6 +130,8 @@ def _bundle_struct_from_provider(bundle):
         resolved_identity = bundle.resolved_identity,
         tools_root = bundle.tools_root,
         tools_path = bundle.tools_path,
+        xls_pin = bundle.xls_pin,
+        xlsynth_crate_pin = bundle.xlsynth_crate_pin,
     )
 
 def _runtime_struct_from_provider(runtime):
@@ -137,6 +167,8 @@ def _toolchain_with_semantics(artifact_selection, ctx):
         runtime_files = artifact_selection.runtime_files,
         runtime_library_path = artifact_selection.runtime_library_path,
         resolved_identity = artifact_selection.resolved_identity,
+        xls_pin = artifact_selection.xls_pin,
+        xlsynth_crate_pin = artifact_selection.xlsynth_crate_pin,
         driver_supports_sv_enum_case_naming_policy = artifact_selection.driver_supports_sv_enum_case_naming_policy,
         driver_supports_sv_struct_field_ordering = artifact_selection.driver_supports_sv_struct_field_ordering,
         dslx_path = _split_nonempty(ctx.attr._dslx_path_flag[BuildSettingInfo].value, ":"),
@@ -430,6 +462,16 @@ def _xls_bundle_impl(ctx):
             resolved_identity = resolved_identity,
             tools_root = runtime.tools_root,
             tools_path = runtime.tools_path,
+            xls_pin = _declared_producer_pin(
+                ctx.attr.xls_version,
+                ctx.attr.xls_git_revision,
+                "XLS pin",
+            ),
+            xlsynth_crate_pin = _declared_producer_pin(
+                ctx.attr.xlsynth_driver_version,
+                ctx.attr.xlsynth_driver_git_revision,
+                "XLSynth crate pin",
+            ),
         ),
         DefaultInfo(files = depset(direct = artifact_inputs)),
     ]
@@ -441,6 +483,10 @@ xls_bundle = rule(
         "driver_supports_sv_enum_case_naming_policy": attr.bool(default = False),
         "driver_supports_sv_struct_field_ordering": attr.bool(default = False),
         "runtime": attr.label(mandatory = True, providers = [XlsRuntimeSurfaceInfo]),
+        "xls_git_revision": attr.string(),
+        "xls_version": attr.string(),
+        "xlsynth_driver_git_revision": attr.string(),
+        "xlsynth_driver_version": attr.string(),
     },
 )
 
@@ -469,6 +515,8 @@ def _merge_toolchain_with_bundle(toolchain, bundle):
         resolved_identity = artifact_selection.resolved_identity,
         tools_root = artifact_selection.tools_root,
         tools_path = artifact_selection.tools_path,
+        xls_pin = artifact_selection.xls_pin,
+        xlsynth_crate_pin = artifact_selection.xlsynth_crate_pin,
         dslx_path = toolchain.dslx_path,
         enable_warnings = toolchain.enable_warnings,
         disable_warnings = toolchain.disable_warnings,

--- a/xls_toolchain.bzl
+++ b/xls_toolchain.bzl
@@ -25,8 +25,8 @@ XlsArtifactBundleInfo = provider(
         "resolved_identity": "Machine-readable resolved producer identity manifest, when requested.",
         "tools_root": "The XLS tool root tree artifact.",
         "tools_path": "Directory path containing the XLS tool binaries.",
-        "xls_pin": "Declared canonical XLS producer pin, or None when the bundle is unpinned.",
-        "xlsynth_crate_pin": "Declared canonical XLSynth producer pin, or None when the bundle is unpinned.",
+        "xls_pin": "Optional declared XLS producer metadata, normalized when its bundle is selected.",
+        "xlsynth_crate_pin": "Optional declared XLSynth producer metadata, normalized when its bundle is selected.",
     },
 )
 

--- a/xls_toolchain.bzl
+++ b/xls_toolchain.bzl
@@ -114,6 +114,32 @@ def _declared_producer_pin(version, git_revision, label, require_xls_release = F
         pin = None
     return pin
 
+def normalize_selected_producer_pin(pin, label, require_xls_release = False):
+    """Canonicalizes optional producer metadata from external Bazel providers."""
+    if pin == None:
+        normalized = None
+    elif not hasattr(pin, "kind") or not hasattr(pin, "value"):
+        fail("{} must provide kind and value fields".format(label))
+    elif type(pin.value) != "string" or not pin.value:
+        fail("{} must provide a nonempty string value".format(label))
+    elif pin.kind == "release_tag":
+        normalized = _declared_producer_pin(
+            pin.value,
+            "",
+            label,
+            require_xls_release = require_xls_release,
+        )
+    elif pin.kind == "git_revision":
+        normalized = _declared_producer_pin(
+            "",
+            pin.value,
+            label,
+            require_xls_release = require_xls_release,
+        )
+    else:
+        fail("{} must use release_tag or git_revision, got: {}".format(label, pin.kind))
+    return normalized
+
 def _single_artifact(target, label):
     files = target[DefaultInfo].files.to_list()
     if len(files) != 1:
@@ -153,8 +179,15 @@ def _bundle_struct_from_provider(bundle):
         resolved_identity = bundle.resolved_identity,
         tools_root = bundle.tools_root,
         tools_path = bundle.tools_path,
-        xls_pin = getattr(bundle, "xls_pin", None),
-        xlsynth_crate_pin = getattr(bundle, "xlsynth_crate_pin", None),
+        xls_pin = normalize_selected_producer_pin(
+            getattr(bundle, "xls_pin", None),
+            "XLS pin",
+            require_xls_release = True,
+        ),
+        xlsynth_crate_pin = normalize_selected_producer_pin(
+            getattr(bundle, "xlsynth_crate_pin", None),
+            "XLSynth crate pin",
+        ),
     )
 
 def _runtime_struct_from_provider(runtime):


### PR DESCRIPTION
## Summary

- Report the independent XLS and XLSynth releases or Git revisions selected by each DSLX library, including library-specific toolchain overrides.
- Expose those versions through a public Starlark provider and opt-in JSON without changing ordinary DSLX build outputs.
- Validate producer metadata while preserving installed, local, and previously defined external toolchains.

## Why This Change

Different DSLX libraries in the same repository can select different toolchain bundles. Consumers that reproduce compilation or calculate structural identities need the versions selected by the specific library, not an assumed repository-wide default.

The reported versions describe declared Bazel configuration. Authenticated downloaded-artifact identity remains a separate security boundary.

## Example

```text
default library:    XLS v0.40.0, XLSynth v0.36.0
overridden library: XLS v0.37.0, XLSynth v0.32.0
```

```shell
bazel build --output_groups=selected_toolchain //path:my_dslx_library
```

```json
{
  "schema_version": 1,
  "xls_pin": {"kind": "release_tag", "value": "v0.40.0"},
  "xlsynth_crate_pin": {"kind": "release_tag", "value": "v0.36.0"}
}
```

## Validation

- `bazel test --build_tests_only //:all //sample/...` - 51 broad regression targets.
- `bazel --bazelrc=/dev/null test --nocache_test_results --disk_cache= -c opt --test_output=errors -- //:selected_toolchain_test //:selected_toolchain_exports_test` - 17 analysis scenarios and six JSON checks.
- `python3 run_presubmit.py -k registered_toolchain_smoke` - seven installed/automatic-toolchain integration cases.
- `bazel build --output_groups=selected_toolchain //sample:sample` - verifies the public machine-readable output.
